### PR TITLE
Improve flag descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REPO=github.com/hellofresh/${NAME}
 VERSION ?= "dev"
 
 BINARY=${NAME}
-BINARY_SRC=$(REPO)/main
+BINARY_SRC=$(REPO)
 
 # Build configuration
 BUILD_DIR ?= $(CURDIR)/out

--- a/cmd/klepto.go
+++ b/cmd/klepto.go
@@ -13,6 +13,7 @@ import (
 var configFile string
 var fromDSN string
 var toDSN string
+var pRecordType string
 var nRows string
 
 // Klepto steals and anonymises databases
@@ -34,10 +35,12 @@ func init() {
 	Klepto.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Path to config file (default is $HOME/.klepto.toml)")
 	Klepto.PersistentFlags().StringVarP(&fromDSN, "from", "f", "root:root@tcp(localhost:3306)/klepto", "MySQL database dsn to steal from")
 	Klepto.PersistentFlags().StringVarP(&toDSN, "to", "t", "", "MySQL database to output to (default writes to stdOut)")
-	Klepto.PersistentFlags().StringVarP(&nRows, "rows", "r", "10000", "Number of rows you want to steal")
+	Klepto.PersistentFlags().StringVarP(&pRecordType, "primary-record-type", "p", "", "Name of specific table or record type you want to steal")
+	Klepto.PersistentFlags().StringVarP(&nRows, "number", "n", "1000", "Number of rows you want to steal")
 	viper.BindPFlag("fromDSN", Klepto.PersistentFlags().Lookup("from"))
 	viper.BindPFlag("toDSN", Klepto.PersistentFlags().Lookup("to"))
-	viper.BindPFlag("nRows", Klepto.PersistentFlags().Lookup("rows"))
+	viper.BindPFlag("nRows", Klepto.PersistentFlags().Lookup("number"))
+	viper.BindPFlag("pRecordType", Klepto.PersistentFlags().Lookup("primary-record-type"))
 }
 
 func initConfig() {


### PR DESCRIPTION
When dumping, we want to be able to specify
the kind of record to dump. A record type roughly
corresponds to one table. The detail is that
a record is not simply the rows from a table,
but also the rows from other tables that the table
has foreign key relationships with.

--number looks like a better description for the flag to specify number of rows.

A sample command would look like this:

klepto \
  --from 'root:root@tcp(localhost:3306)/fromDB' \
  --to 'root:root@tcp(localhost:3306)/toDB' \
  --primary-record-type 'user' \
  --number '10'