### PR TITLE
Add support for primary_record_type in the config

### DIFF
--- a/database/mysql/relresolver_test.go
+++ b/database/mysql/relresolver_test.go
@@ -32,11 +32,10 @@ func TestReadPrimaryRecord(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed creating a test config: %s", err)
 	}
-
 	// Set expectation
 	expectedRecordType := "users"
 
-	// Call method
+	// Check expectation
 	recordType, err := f.readPrimaryRecord()
 
 	// Check that readPrimaryRecord() reads the given configuration

--- a/example.toml
+++ b/example.toml
@@ -2,3 +2,6 @@
 "users.name" = "FirstName"
 "users.username" = "EmailAddress"
 "users.password" = "literal:1234"
+
+[primary_record_type]
+"users" = 1000


### PR DESCRIPTION
With this set, we can determine the primary_record_type (or table).
The user can also set the number of records that they want in the config.