### PR TITLE
Read relationships from config

### DIFF
--- a/database/mysql/relresolver.go
+++ b/database/mysql/relresolver.go
@@ -1,0 +1,35 @@
+package mysql
+
+import (
+	"errors"
+
+	"github.com/spf13/viper"
+)
+
+// ConfigReader ...
+type ConfigReader struct {
+	v *viper.Viper
+}
+
+func (g *ConfigReader) readPrimaryRecord() (pRecordType string, err error) {
+	c := g.v.Sub("primary_record_type")
+	pRecordType = c.AllKeys()[0] // TODO: In the exciting future when
+	// users can configure multiple record_types, get all keys, not just the first one.
+	if pRecordType == "" {
+		return "", errors.New("warning: primary_record_type not set in config")
+	}
+	return pRecordType, nil
+}
+
+// Read all relationships
+func (g *ConfigReader) readRelationships() (map[string]string, error) {
+	c := g.v.Sub("relationships")
+	children := c.AllKeys()
+	rels := make(map[string]string, len(children))
+	for _, ch := range children {
+		rels[ch] = c.GetString(ch)
+	}
+
+	return rels, nil
+
+}

--- a/database/mysql/relresolver_test.go
+++ b/database/mysql/relresolver_test.go
@@ -1,0 +1,82 @@
+package mysql
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+type primaryRecord struct{}
+
+// Pass and read some config
+func createConfig(data string) (cReader ConfigReader, err error) {
+	v := viper.New()
+	v.SetConfigType("toml")
+	var config = []byte(data)
+	f := ConfigReader{
+		v: v,
+	}
+	err = f.v.ReadConfig(bytes.NewBuffer(config))
+	if err != nil {
+		return ConfigReader{}, err
+	}
+	return f, nil
+}
+
+func TestReadPrimaryRecord(t *testing.T) {
+	f, err := createConfig(`
+[primary_record_type]
+"users" = 1
+		`)
+	if err != nil {
+		t.Errorf("Failed creating a test config: %s", err)
+	}
+
+	// Set expectation
+	expectedRecordType := "users"
+
+	// Call method
+	recordType, err := f.readPrimaryRecord()
+
+	// Check that readPrimaryRecord() reads the given configuration
+	if err != nil {
+		t.Fatalf("Expected no error. Got %s", err)
+	}
+	if expectedRecordType != recordType {
+		t.Fatalf("Expected %s. Got %s", expectedRecordType, recordType)
+	}
+}
+
+func TestReadRelationships(t *testing.T) {
+	// given a config of relationships,
+	f, err := createConfig(`
+[relationships]
+"page_views.login_id" = "logins.id"
+"logins.user_id" = "users.id"
+		`)
+	if err != nil {
+		t.Fatalf("Failed creating a test config: %s", err)
+	}
+	// Set expections
+	expectedRels := map[string]string{
+		"logins.user_id":      "users.id",
+		"page_views.login_id": "logins.id",
+	}
+
+	// read configured relationships
+	relationships, err := f.readRelationships()
+
+	if err != nil {
+		t.Fatalf("Expected no error. Got %s", err)
+	}
+
+	// Check that all relationships are read correctly
+	for k, expectation := range expectedRels {
+		if expectation != relationships[k] {
+			t.Logf("relationships: %v", relationships)
+			t.Fatalf("Expected %s. Got %s", expectation, relationships[k])
+		}
+	}
+
+}


### PR DESCRIPTION
Provide a way to explicitly set relationships in the
configuration file. Read the configurations and
store them in a convenient map that we will
use for future action.