### PR TITLE
Dump configured record

### DIFF
--- a/cmd/klepto.go
+++ b/cmd/klepto.go
@@ -35,7 +35,7 @@ func init() {
 	Klepto.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Path to config file (default is $HOME/.klepto.toml)")
 	Klepto.PersistentFlags().StringVarP(&fromDSN, "from", "f", "root:root@tcp(localhost:3306)/klepto", "MySQL database dsn to steal from")
 	Klepto.PersistentFlags().StringVarP(&toDSN, "to", "t", "", "MySQL database to output to (default writes to stdOut)")
-	Klepto.PersistentFlags().StringVarP(&pRecordType, "primary-record-type", "p", "", "Name of specific table or record type you want to steal")
+	Klepto.PersistentFlags().StringVarP(&pRecordType, "primary_record_type", "p", "", "Name of specific table or record type you want to steal")
 	Klepto.PersistentFlags().StringVarP(&nRows, "number", "n", "1000", "Number of rows you want to steal")
 	viper.BindPFlag("fromDSN", Klepto.PersistentFlags().Lookup("from"))
 	viper.BindPFlag("toDSN", Klepto.PersistentFlags().Lookup("to"))

--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -27,10 +27,9 @@ func RunSteal(cmd *cobra.Command, args []string) {
 
 	spinner := wow.New(os.Stdout, spin.Get(spin.Smiley), " Stealing...")
 	spinner.Start()
-
-	store := database.NewStorage(inputConn)
+	configReader := database.NewConfigReader(viper.GetViper())
+	store := database.NewStorage(inputConn, *configReader)
 	anonyimiser := mysql.NewAnonymiser(store)
-	configReader := mysql.NewConfigReader(viper.GetViper())
 	dumper := mysql.NewDumper(store, anonyimiser, *configReader)
 	structure, err := dumper.DumpStructure()
 	if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -27,7 +27,7 @@ type Cell struct {
 
 // Connect to a (for now) MySQL database with the provided DSN
 func Connect(dsn string) (*sql.DB, error) {
-	conn, err := sql.Open("mysql", dsn)
+	conn, err := sql.Open("mysql", dsn+"?parseTime=true")
 	if err != nil {
 		return nil, err
 	}

--- a/database/mysql/anonymiser.go
+++ b/database/mysql/anonymiser.go
@@ -32,7 +32,7 @@ func NewAnonymiser(s database.Store) *Anonymiser {
 // AnonymiseRows grabs the data from the provided database table and runs Faker against
 // columns specified in config file.
 func (a *Anonymiser) AnonymiseRows(table string, rowChan chan<- []*database.Cell, endChan chan<- bool) error {
-	rows, err := a.store.Rows(table)
+	rows, err := a.store.GetRows(table)
 	if err != nil {
 		return err
 	}

--- a/database/mysql/anonymiser.go
+++ b/database/mysql/anonymiser.go
@@ -61,8 +61,13 @@ func (a *Anonymiser) AnonymiseRows(table string, rowChan chan<- []*database.Cell
 				if err := rows.Scan(nFields...); err != nil {
 					return err
 				}
-				seed := reflect.ValueOf(nFields[idx]).Elem()
-				cell, err := KeepSeedValueUnchanged(column, seed, reflect.TypeOf(seed).Kind())
+				// Perform type conversions before internal scan
+				vPtr := nFields[idx]
+				v := vPtr.(*interface{})
+				scanner := new(utils.TypeScanner)
+				scanner.Scan(*v)
+
+				cell, err := KeepSeedValueUnchanged(column, scanner.Value, scanner.Detected)
 				if err != nil {
 					return err
 				}

--- a/database/mysql/dumper.go
+++ b/database/mysql/dumper.go
@@ -111,9 +111,8 @@ func (d *Dumper) bufferer(buf *bytes.Buffer, rowChan chan []*database.Cell, done
 				if c.Type == "string" {
 					buf.WriteString(fmt.Sprintf("\"%s\"", c.Value))
 				} else {
-					buf.WriteString(fmt.Sprintf("%s", c.Value))
+					buf.WriteString(fmt.Sprintf("%v", c.Value))
 				}
-
 				if i == len-1 {
 					buf.WriteString("),")
 				} else {

--- a/database/mysql/dumper.go
+++ b/database/mysql/dumper.go
@@ -14,13 +14,13 @@ import (
 type Dumper struct {
 	store  database.Store
 	anon   database.Anonymiser
-	config ConfigReader
+	config database.ConfigReader
 	out    chan []*database.Cell
 	done   chan bool
 }
 
 // NewDumper is the constructor for MySQLDumper
-func NewDumper(s database.Store, a database.Anonymiser, c ConfigReader) *Dumper {
+func NewDumper(s database.Store, a database.Anonymiser, c database.ConfigReader) *Dumper {
 	return &Dumper{
 		store:  s,
 		anon:   a,
@@ -132,7 +132,7 @@ func (d *Dumper) bufferer(buf *bytes.Buffer, rowChan chan []*database.Cell, done
 // - from the db
 // but don't do both.
 func (d *Dumper) setTables() (tables []string, err error) {
-	table, err := d.config.readPrimaryRecord()
+	table, err := d.config.ReadPrimaryRecord()
 	if err != nil {
 		return
 	}

--- a/database/mysql/seeder.go
+++ b/database/mysql/seeder.go
@@ -2,7 +2,6 @@ package mysql
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/hellofresh/klepto/database"
 )
@@ -12,9 +11,8 @@ type Seeder struct {
 }
 
 // KeepSeedValueUnchanged leaves primary key or any other non-anonymous fields unchanged.
-func KeepSeedValueUnchanged(column string, value, typ interface{}) (*database.Cell, error) {
-	kind := fmt.Sprintf("%s", reflect.TypeOf(value).Kind())
-	cell := &database.Cell{Column: column, Value: value, Type: kind}
+func KeepSeedValueUnchanged(column string, value interface{}, typ string) (*database.Cell, error) {
+	cell := &database.Cell{Column: column, Value: value, Type: typ}
 	if cell.Type != "" {
 		return cell, nil
 	}

--- a/database/mysql/seeder_test.go
+++ b/database/mysql/seeder_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 type seedsTestPair struct {
-	column     string
-	value, typ interface{}
-	cell       *database.Cell
+	column string
+	value  interface{}
+	typ    string
+	cell   *database.Cell
 }
 
 var seedTests = []seedsTestPair{

--- a/database/relresolver.go
+++ b/database/relresolver.go
@@ -1,7 +1,8 @@
-package mysql
+package database
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/viper"
 )
@@ -24,7 +25,7 @@ func NewConfigReader(v *viper.Viper) *ConfigReader {
 }
 
 // ReadPrimaryRecord ...
-func (g *ConfigReader) readPrimaryRecord() (pRecordType string, err error) {
+func (g *ConfigReader) ReadPrimaryRecord() (pRecordType string, err error) {
 	c := g.v.Sub("primary_record_type")
 	pRecordType = c.AllKeys()[0] // TODO: In the exciting future when
 	// users can configure multiple record_types, get all keys, not just the first one.
@@ -33,7 +34,16 @@ func (g *ConfigReader) readPrimaryRecord() (pRecordType string, err error) {
 	}
 	return pRecordType, nil
 }
-<<<<<<< HEAD
+
+// ReadPrimaryRecordLimit returns configured number of records to return
+func (g *ConfigReader) ReadPrimaryRecordLimit() (limit string, err error) {
+	pRecord, err := g.ReadPrimaryRecord()
+	if err != nil {
+		return "", err
+	}
+	c := g.v.GetString(fmt.Sprintf("primary_record_type.%s", pRecord))
+	return c, nil
+}
 
 // Read all relationships
 func (g *ConfigReader) readRelationships() (map[string]string, error) {
@@ -47,5 +57,3 @@ func (g *ConfigReader) readRelationships() (map[string]string, error) {
 	return rels, nil
 
 }
-=======
->>>>>>> Wire reading tables in

--- a/database/relresolver_test.go
+++ b/database/relresolver_test.go
@@ -1,4 +1,4 @@
-package mysql
+package database
 
 import (
 	"bytes"

--- a/database/storage.go
+++ b/database/storage.go
@@ -45,16 +45,11 @@ SET NAMES utf8;
 SET FOREIGN_KEY_CHECKS = 0;
 
 `
-	var hostname string
-	row := s.conn.QueryRow("SELECT @@hostname")
-	err := row.Scan(&hostname)
+	hostname, err := s.hostname()
 	if err != nil {
 		return "", err
 	}
-
-	var db string
-	row = s.conn.QueryRow("SELECT DATABASE()")
-	err = row.Scan(&db)
+	db, err := s.database()
 	if err != nil {
 		return "", err
 	}
@@ -137,9 +132,54 @@ func (s *Storage) rows(table string) (*sql.Rows, error) {
 }
 
 func (s *Storage) nRows(table string, n string) (*sql.Rows, error) {
-	nRows, err := s.conn.Query(fmt.Sprintf("SELECT * FROM `%s` LIMIT %s", table, n))
+	column, err := s.primaryColumn(table)
+	if err != nil {
+		return nil, err
+	}
+	nRows, err := s.conn.Query(fmt.Sprintf("SELECT * FROM %s ORDER BY %s DESC LIMIT ?", table, column), n)
 	if err != nil {
 		return nRows, err
 	}
 	return nRows, nil
+}
+
+// database returns the name of the database.
+func (s *Storage) database() (string, error) {
+	row := s.conn.QueryRow("SELECT DATABASE()")
+	var db string
+	err := row.Scan(&db)
+	if err != nil {
+		return "", err
+	}
+	return db, nil
+}
+
+// hostname returns the hostname
+func (s *Storage) hostname() (string, error) {
+	row := s.conn.QueryRow("SELECT @@hostname")
+	var hostname string
+	err := row.Scan(&hostname)
+	if err != nil {
+		return "", err
+	}
+	return hostname, nil
+}
+
+func (s *Storage) primaryColumn(table string) (string, error) {
+	q := `SELECT COLUMN_NAME
+FROM information_schema.COLUMNS
+WHERE (TABLE_SCHEMA = ?)
+AND (TABLE_NAME = ?)
+AND (COLUMN_KEY = "PRI")`
+	dbName, err := s.database()
+	if err != nil {
+		return "", fmt.Errorf("Could not get database name")
+	}
+	row := s.conn.QueryRow(q, dbName, table)
+	var priKeyColName string
+	serr := row.Scan(&priKeyColName)
+	if serr != nil {
+		return "", fmt.Errorf("Could not get the primary key column name: %v", serr)
+	}
+	return priKeyColName, nil
 }

--- a/database/storage.go
+++ b/database/storage.go
@@ -12,17 +12,21 @@ type Store interface {
 	GetTableStructure(string) (string, error)
 	GetColumns(string) ([]string, error)
 	GetPreamble() (string, error)
-	Rows(string) (*sql.Rows, error)
+	GetRows(string) (*sql.Rows, error)
 }
 
 // Storage ...
 type Storage struct {
-	conn *sql.DB
+	conn   *sql.DB
+	config ConfigReader
 }
 
 // NewStorage ...
-func NewStorage(conn *sql.DB) *Storage {
-	return &Storage{conn: conn}
+func NewStorage(conn *sql.DB, c ConfigReader) *Storage {
+	return &Storage{
+		conn:   conn,
+		config: c,
+	}
 }
 
 // GetPreamble puts a big old comment at the top of the database dump.
@@ -108,11 +112,34 @@ func (s *Storage) GetTableStructure(table string) (stmt string, err error) {
 	return
 }
 
+// GetRows returns rows. If primary_record_type has been
+// set and a number is given, return only those
+// number of rows.
+func (s *Storage) GetRows(table string) (*sql.Rows, error) {
+	n, err := s.config.ReadPrimaryRecordLimit()
+	if err != nil {
+		return nil, err
+	}
+	if n != "" {
+		return s.nRows(table, n)
+	}
+	return s.rows(table)
+
+}
+
 // Rows returns a list of all rows in a table
-func (s *Storage) Rows(table string) (*sql.Rows, error) {
+func (s *Storage) rows(table string) (*sql.Rows, error) {
 	rows, err := s.conn.Query(fmt.Sprintf("SELECT * FROM `%s`", table))
 	if err != nil {
 		return rows, err
 	}
 	return rows, nil
+}
+
+func (s *Storage) nRows(table string, n string) (*sql.Rows, error) {
+	nRows, err := s.conn.Query(fmt.Sprintf("SELECT * FROM `%s` LIMIT %s", table, n))
+	if err != nil {
+		return nRows, err
+	}
+	return nRows, nil
 }


### PR DESCRIPTION
We want to use only the primary record to generate
the query if the user specifies that in the configuration.
Otherwise, we want to get tables from the db and dump everything.
Next up, we dump related tables too.