### PR TITLE
By default, order records in descending order by primary key

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -27,7 +27,7 @@ type Cell struct {
 
 // Connect to a (for now) MySQL database with the provided DSN
 func Connect(dsn string) (*sql.DB, error) {
-	conn, err := sql.Open("mysql", dsn)
+	conn, err := sql.Open("mysql", dsn+"?parseTime=true")
 	if err != nil {
 		return nil, err
 	}

--- a/database/mysql/anonymiser.go
+++ b/database/mysql/anonymiser.go
@@ -61,8 +61,13 @@ func (a *Anonymiser) AnonymiseRows(table string, rowChan chan<- []*database.Cell
 				if err := rows.Scan(nFields...); err != nil {
 					return err
 				}
-				seed := reflect.ValueOf(nFields[idx]).Elem()
-				cell, err := KeepSeedValueUnchanged(column, seed, reflect.TypeOf(seed).Kind())
+				// Perform type conversions before internal scan
+				vPtr := nFields[idx]
+				v := vPtr.(*interface{})
+				scanner := new(utils.TypeScanner)
+				scanner.Scan(*v)
+
+				cell, err := KeepSeedValueUnchanged(column, scanner.Value, scanner.Detected)
 				if err != nil {
 					return err
 				}

--- a/database/mysql/dumper.go
+++ b/database/mysql/dumper.go
@@ -111,9 +111,8 @@ func (d *Dumper) bufferer(buf *bytes.Buffer, rowChan chan []*database.Cell, done
 				if c.Type == "string" {
 					buf.WriteString(fmt.Sprintf("\"%s\"", c.Value))
 				} else {
-					buf.WriteString(fmt.Sprintf("%s", c.Value))
+					buf.WriteString(fmt.Sprintf("%v", c.Value))
 				}
-
 				if i == len-1 {
 					buf.WriteString("),")
 				} else {

--- a/database/mysql/seeder.go
+++ b/database/mysql/seeder.go
@@ -2,7 +2,6 @@ package mysql
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/hellofresh/klepto/database"
 )
@@ -12,9 +11,8 @@ type Seeder struct {
 }
 
 // KeepSeedValueUnchanged leaves primary key or any other non-anonymous fields unchanged.
-func KeepSeedValueUnchanged(column string, value, typ interface{}) (*database.Cell, error) {
-	kind := fmt.Sprintf("%s", reflect.TypeOf(value).Kind())
-	cell := &database.Cell{Column: column, Value: value, Type: kind}
+func KeepSeedValueUnchanged(column string, value interface{}, typ string) (*database.Cell, error) {
+	cell := &database.Cell{Column: column, Value: value, Type: typ}
 	if cell.Type != "" {
 		return cell, nil
 	}

--- a/database/mysql/seeder_test.go
+++ b/database/mysql/seeder_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 type seedsTestPair struct {
-	column     string
-	value, typ interface{}
-	cell       *database.Cell
+	column string
+	value  interface{}
+	typ    string
+	cell   *database.Cell
 }
 
 var seedTests = []seedsTestPair{

--- a/database/storage.go
+++ b/database/storage.go
@@ -45,19 +45,8 @@ SET NAMES utf8;
 SET FOREIGN_KEY_CHECKS = 0;
 
 `
-	var hostname string
-	row := s.conn.QueryRow("SELECT @@hostname")
-	err := row.Scan(&hostname)
-	if err != nil {
-		return "", err
-	}
-
-	var db string
-	row = s.conn.QueryRow("SELECT DATABASE()")
-	err = row.Scan(&db)
-	if err != nil {
-		return "", err
-	}
+	hostname, _ := s.hostname()
+	db, _ := s.database()
 
 	return fmt.Sprintf(preamble, hostname, db, time.Now().Format(time.RFC1123Z)), nil
 }
@@ -142,4 +131,26 @@ func (s *Storage) nRows(table string, n string) (*sql.Rows, error) {
 		return nRows, err
 	}
 	return nRows, nil
+}
+
+// database returns the name of the database.
+func (s *Storage) database() (string, error) {
+	var db string
+	row := s.conn.QueryRow("SELECT DATABASE()")
+	err := row.Scan(&db)
+	if err != nil {
+		return "", err
+	}
+	return db, nil
+}
+
+// hostname returns the hostname
+func (s *Storage) hostname() (string, error) {
+	var hostname string
+	row := s.conn.QueryRow("SELECT @@hostname")
+	err := row.Scan(&hostname)
+	if err != nil {
+		return "", err
+	}
+	return hostname, nil
 }

--- a/database/storage.go
+++ b/database/storage.go
@@ -136,8 +136,7 @@ func (s *Storage) nRows(table string, n string) (*sql.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	q := fmt.Sprintf("SELECT * FROM `%s` ORDER BY %s DESC LIMIT %s", table, column, n)
-	nRows, err := s.conn.Query(q)
+	nRows, err := s.conn.Query(fmt.Sprintf("SELECT * FROM %s ORDER BY %s DESC LIMIT ?", table, column), n)
 	if err != nil {
 		return nRows, err
 	}
@@ -169,14 +168,14 @@ func (s *Storage) hostname() (string, error) {
 func (s *Storage) primaryColumn(table string) (string, error) {
 	q := `SELECT COLUMN_NAME
 FROM information_schema.COLUMNS
-WHERE (TABLE_SCHEMA = "%s")
-AND (TABLE_NAME = "%s")
+WHERE (TABLE_SCHEMA = ?)
+AND (TABLE_NAME = ?)
 AND (COLUMN_KEY = "PRI")`
 	dbName, err := s.database()
 	if err != nil {
 		return "", fmt.Errorf("Could not get database name")
 	}
-	row := s.conn.QueryRow(fmt.Sprintf(q, dbName, table))
+	row := s.conn.QueryRow(q, dbName, table)
 	var priKeyColName string
 	serr := row.Scan(&priKeyColName)
 	if serr != nil {


### PR DESCRIPTION
Typically, during troubleshooting and testing, we want
the newest records