### PR TITLE
Get GitHub token from options

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,7 +35,7 @@ func NewUpdateCmd() *cobra.Command {
 
 // RunUpdate runs the update command
 func RunUpdate(opts *UpdateOptions) {
-	resolver, err := goupdater.NewGithub("", githubOwner, githubRepo)
+	resolver, err := goupdater.NewGithub(opts.token, githubOwner, githubRepo)
 	failOnError(err, "could not create the updater client")
 
 	updated, err := goupdater.Update(resolver, version)


### PR DESCRIPTION
Fixes this error when you try to `./klepto update`
```
⨯ could not create the updater client error=to check for updates you must provide a github token
```