### PR TITLE
Get database structure not table structure

### DIFF
--- a/pkg/anonymiser/anonymiser_test.go
+++ b/pkg/anonymiser/anonymiser_test.go
@@ -14,10 +14,10 @@ import (
 
 type mockReader struct{}
 
-func (m *mockReader) GetTables() ([]string, error)             { return []string{"table_test"}, nil }
-func (m *mockReader) GetTableStructure(string) (string, error) { return "", nil }
-func (m *mockReader) GetColumns(string) ([]string, error)      { return []string{"column_test"}, nil }
-func (m *mockReader) GetPreamble() (string, error)             { return "", nil }
+func (m *mockReader) GetTables() ([]string, error)        { return []string{"table_test"}, nil }
+func (m *mockReader) GetStructure() (string, error)       { return "", nil }
+func (m *mockReader) GetColumns(string) ([]string, error) { return []string{"column_test"}, nil }
+func (m *mockReader) GetPreamble() (string, error)        { return "", nil }
 func (m *mockReader) ReadTable(tableName string, rowChan chan<- *database.Row) error {
 	row := make(database.Row)
 	row["column_test"] = &database.Cell{Type: "string", Value: "to_be_anonimised"}

--- a/pkg/dumper/text/dumper.go
+++ b/pkg/dumper/text/dumper.go
@@ -31,12 +31,14 @@ func (d *textDumper) Dump() error {
 	}
 
 	buf := os.Stdout
+
+	structure, err := d.reader.GetStructure()
+	if err != nil {
+		return err
+	}
+	buf.WriteString(structure)
+
 	for _, tbl := range tables {
-		structure, err := d.reader.GetTableStructure(tbl)
-		if err != nil {
-			return err
-		}
-		buf.WriteString(structure)
 
 		columns, err := d.reader.GetColumns(tbl)
 		if err != nil {

--- a/pkg/dumper/text/dumper_test.go
+++ b/pkg/dumper/text/dumper_test.go
@@ -7,7 +7,7 @@ func (st *storeStub) getTables() (tables []string, err error) {
 	return
 }
 
-func (st *storeStub) getTableStructure(table string) (structure string, err error) {
+func (st *storeStub) getStructure() (structure string, err error) {
 	return
 }
 

--- a/pkg/reader/postgres/pg_dump.go
+++ b/pkg/reader/postgres/pg_dump.go
@@ -9,7 +9,7 @@ import (
 
 type (
 	PgDump interface {
-		GetTableStructure(table string) (stmt string, err error)
+		GetStructure() (stmt string, err error)
 	}
 
 	pgDump struct {
@@ -30,16 +30,14 @@ func NewPgDump(dsn string) (PgDump, error) {
 	}, nil
 }
 
-func (p *pgDump) GetTableStructure(table string) (stmt string, err error) {
+func (p *pgDump) GetStructure() (string, error) {
 	logger := log.WithFields(log.Fields{
 		"command": p.command,
-		"table":   table,
 	})
 
 	cmd := exec.Command(
 		p.command,
 		"--dbname", p.dsn,
-		"--table", table,
 		"--schema-only",
 	)
 

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -19,10 +19,14 @@ type (
 
 	// Reader provides an interface to access database stores.
 	Reader interface {
+		// GetTables returns a list of all databases tables
 		GetTables() ([]string, error)
-		GetTableStructure(string) (string, error)
+		// GetColumns return a list of all columns for a given table
 		GetColumns(string) ([]string, error)
+		// GetStructure returns the SQL used to create the database tables
+		GetStructure() (string, error)
 		GetPreamble() (string, error)
+		// ReadTable returns a channel with all database rows
 		ReadTable(string, chan<- *database.Row) error
 	}
 )


### PR DESCRIPTION
This PR changes `reader.Reader` to dump the database for the tables and not just a table at a time. This makes postgres structure a lot more usable.