### PR TITLE
Parse dumper dsn, and output to os streams

### DIFF
--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -36,7 +36,7 @@ func NewStealCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&opts.from, "from", "f", "root:root@tcp(localhost:3306)/klepto", "Database dsn to steal from")
-	cmd.PersistentFlags().StringVarP(&opts.to, "to", "t", "", "Database to output to (default writes to stdOut)")
+	cmd.PersistentFlags().StringVarP(&opts.to, "to", "t", "os://stdout/", "Database to output to (default writes to stdOut)")
 	cmd.PersistentFlags().IntVarP(&opts.rows, "number", "n", 1000, "Number of rows you want to steal")
 
 	return cmd

--- a/pkg/dsn/dsn.go
+++ b/pkg/dsn/dsn.go
@@ -2,7 +2,6 @@ package dsn
 
 import (
 	"errors"
-	"log"
 	"net"
 	"net/url"
 	"reflect"
@@ -44,8 +43,6 @@ func Parse(s string) (*DSN, error) {
 		return nil, ErrInvalidDsn
 	}
 	names := regex.SubexpNames()
-	log.Printf("matches: %v", matches)
-
 	vof := reflect.ValueOf(dsn).Elem()
 
 	if len(matches) > 0 {

--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -3,6 +3,7 @@ package dumper
 import (
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/reader"
+	"github.com/pkg/errors"
 )
 
 type (
@@ -24,7 +25,6 @@ type (
 func NewDumper(dsn string, rdr reader.Reader) (dumper Dumper, err error) {
 	drivers.Range(func(key, value interface{}) bool {
 		driver, _ := value.(Driver)
-
 		if !driver.IsSupported(dsn) {
 			return true
 		}
@@ -32,6 +32,12 @@ func NewDumper(dsn string, rdr reader.Reader) (dumper Dumper, err error) {
 		dumper, err = driver.NewConnection(dsn, rdr)
 		return false
 	})
+
+	if dumper == nil && err == nil {
+		err = errors.New("no supported driver found")
+	}
+
+	err = errors.Wrapf(err, "could not create dumper for dsn: '%v'", dsn)
 
 	return
 }

--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/reader"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type (
@@ -28,6 +29,7 @@ func NewDumper(dsn string, rdr reader.Reader) (dumper Dumper, err error) {
 		if !driver.IsSupported(dsn) {
 			return true
 		}
+		log.WithField("driver", key).Debug("Found driver")
 
 		dumper, err = driver.NewConnection(dsn, rdr)
 		return false

--- a/pkg/dumper/mysql/mysql.go
+++ b/pkg/dumper/mysql/mysql.go
@@ -12,6 +12,10 @@ import (
 type driver struct{}
 
 func (m *driver) IsSupported(dsn string) bool {
+	if dsn == "" {
+		return false
+	}
+
 	_, err := mysql.ParseDSN(dsn)
 	return err == nil
 }

--- a/pkg/dumper/query/query.go
+++ b/pkg/dumper/query/query.go
@@ -13,7 +13,7 @@ func (m *driver) IsSupported(dsn string) bool {
 	if err != nil {
 		return false
 	}
-	return d.Type == "file" || d.Type == "os"
+	return d.Type == "os"
 }
 
 func (m *driver) NewConnection(dsn string, rdr reader.Reader) (dumper.Dumper, error) {

--- a/pkg/dumper/query/query.go
+++ b/pkg/dumper/query/query.go
@@ -1,8 +1,7 @@
 package query
 
 import (
-	"os"
-
+	parser "github.com/hellofresh/klepto/pkg/dsn"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	"github.com/hellofresh/klepto/pkg/reader"
 )
@@ -10,11 +9,19 @@ import (
 type driver struct{}
 
 func (m *driver) IsSupported(dsn string) bool {
-	return true
+	d, err := parser.Parse(dsn)
+	if err != nil {
+		return false
+	}
+	return d.Type == "file" || d.Type == "os"
 }
 
 func (m *driver) NewConnection(dsn string, rdr reader.Reader) (dumper.Dumper, error) {
-	return NewDumper(os.Stdout, rdr), nil
+	writer, err := getOutputWriter(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return NewDumper(writer, rdr), nil
 }
 
 func init() {

--- a/pkg/dumper/query/writer.go
+++ b/pkg/dumper/query/writer.go
@@ -1,0 +1,36 @@
+package query
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	parser "github.com/hellofresh/klepto/pkg/dsn"
+)
+
+func getOsWriter(address string) io.Writer {
+	if address == "stderr" {
+		return os.Stderr
+	}
+	if address == "stdout" {
+		return os.Stdout
+	}
+	return nil
+}
+
+// TODO: Implement writer interface for file.
+func getOutputWriter(dsn string) (io.Writer, error) {
+	config, err := parser.Parse(dsn)
+	if err != nil {
+		return nil, err
+	}
+	switch config.Type {
+	case "os":
+		return getOsWriter(config.Address), nil
+	case "file":
+		return getOsWriter(config.Address), nil
+	default:
+		return nil, fmt.Errorf("Unknown output writer type: %v", config.Type)
+	}
+
+}

--- a/pkg/dumper/query/writer.go
+++ b/pkg/dumper/query/writer.go
@@ -27,8 +27,6 @@ func getOutputWriter(dsn string) (io.Writer, error) {
 	switch config.Type {
 	case "os":
 		return getOsWriter(config.Address), nil
-	case "file":
-		return getOsWriter(config.Address), nil
 	default:
 		return nil, fmt.Errorf("Unknown output writer type: %v", config.Type)
 	}

--- a/pkg/dumper/query/writer_test.go
+++ b/pkg/dumper/query/writer_test.go
@@ -1,0 +1,30 @@
+package query
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var tests = []struct {
+	Dsn    string
+	Writer io.Writer
+}{
+	{Dsn: "os://stdout/", Writer: os.Stdout},
+	{Dsn: "os://stderr/", Writer: os.Stderr},
+}
+
+func TestWriter(t *testing.T) {
+	for _, test := range tests {
+		w, err := getOutputWriter(test.Dsn)
+		if err != nil {
+			t.Error("Encountered error when getting output writer",
+				err)
+		}
+		if test.Dsn != "" {
+			assert.Equal(t, test.Writer, w)
+		}
+	}
+}

--- a/pkg/reader/mysql/mysql.go
+++ b/pkg/reader/mysql/mysql.go
@@ -10,6 +10,10 @@ import (
 type driver struct{}
 
 func (m *driver) IsSupported(dsn string) bool {
+	if dsn == "" {
+		return false
+	}
+
 	_, err := mysql.ParseDSN(dsn)
 	return err == nil
 }

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -49,7 +49,6 @@ type (
 func Connect(dsn string) (reader Reader, err error) {
 	drivers.Range(func(key, value interface{}) bool {
 		driver, _ := value.(Driver)
-
 		if !driver.IsSupported(dsn) {
 			return true
 		}


### PR DESCRIPTION
We can do `klepto steal --from 'root:@tcp(localhost:3307)/fromDB' -c .klepto.toml --to 'os://stdout/'`

`os://stdout` without a trailing slash gives an error that the dsn is invalid. Will fix that in another PR.