### PR TITLE
Improve mysql dumper

### DIFF
--- a/pkg/dumper/mysql/dumper.go
+++ b/pkg/dumper/mysql/dumper.go
@@ -105,15 +105,16 @@ func (p *myDumper) insertIntoTable(txn *sql.Tx, tableName string, rowChan <-chan
 			// Put the data in the correct order and format
 			rowValues := make([]string, len(columns))
 			for i, col := range columns {
-				if row[col] == nil {
+				switch v := row[col].(type) {
+				case nil:
 					rowValues[i] = "NULL"
-				} else {
-					s, ok := row[col].(string)
-					if ok {
-						rowValues[i] = s
-					} else {
-						rowValues[i] = string(row[col].([]uint8))
-					}
+				case string:
+					rowValues[i] = row[col].(string)
+				case []uint8:
+					rowValues[i] = string(row[col].([]uint8))
+				default:
+					log.Info("we have an unhandled type: %T \n. attempting to convert to a string \n", v)
+					rowValues[i] = row[col].(string)
 				}
 			}
 

--- a/pkg/dumper/mysql/dumper.go
+++ b/pkg/dumper/mysql/dumper.go
@@ -113,7 +113,7 @@ func (p *myDumper) insertIntoTable(txn *sql.Tx, tableName string, rowChan <-chan
 				case []uint8:
 					rowValues[i] = string(row[col].([]uint8))
 				default:
-					log.Info("we have an unhandled type: %T \n. attempting to convert to a string \n", v)
+					log.WithField("type", v).Info("we have an unhandled type. attempting to convert to a string \n")
 					rowValues[i] = row[col].(string)
 				}
 			}

--- a/pkg/dumper/mysql/dumper.go
+++ b/pkg/dumper/mysql/dumper.go
@@ -108,7 +108,12 @@ func (p *myDumper) insertIntoTable(txn *sql.Tx, tableName string, rowChan <-chan
 				if row[col] == nil {
 					rowValues[i] = "NULL"
 				} else {
-					rowValues[i] = string(row[col].([]uint8))
+					s, ok := row[col].(string)
+					if ok {
+						rowValues[i] = s
+					} else {
+						rowValues[i] = string(row[col].([]uint8))
+					}
 				}
 			}
 

--- a/pkg/reader/mysql/reader.go
+++ b/pkg/reader/mysql/reader.go
@@ -89,7 +89,7 @@ func (s *storage) GetStructure() (string, error) {
 	}
 
 	buf := bytes.NewBufferString(preamble)
-	buf.WriteString("SET FOREIGN_KEY_CHECKS=0;")
+	buf.WriteString("SET FOREIGN_KEY_CHECKS=0;\n")
 	for _, tableName := range tables {
 		var stmtTableName, tableStmt string
 		err := s.connection.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s", s.QuoteIdentifier(tableName))).Scan(&stmtTableName, &tableStmt)


### PR DESCRIPTION
- Minor: adds new line when dumping to stdout
- Fixes a bug with interface conversion when dumping into a target database
```
panic: interface conversion: interface {} is []uint8, not string

goroutine 25 [running]:
github.com/hellofresh/klepto/pkg/dumper/mysql.(*myDumper).insertIntoTable.func1(0xc420074480, 0xc4200f8d00, 0x5, 0x8, 0xc42001b0b0, 0xc42000e1d8)
	/Users/jojoo/go/src/github.com/hellofresh/klepto/pkg/dumper/mysql/dumper.go:106 +0x61b
created by github.com/hellofresh/klepto/pkg/dumper/mysql.(*myDumper).insertIntoTable
	/Users/jojoo/go/src/github.com/hellofresh/klepto/pkg/dumper/mysql/dumper.go:88 +0x4ce
```