### PR TITLE
Add extra flags

### DIFF
--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -1,6 +1,8 @@
 package dumper
 
 import (
+	"time"
+
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/reader"
 	"github.com/pkg/errors"
@@ -11,7 +13,7 @@ type (
 	// Driver is a driver interface used to support multiple drivers
 	Driver interface {
 		IsSupported(dsn string) bool
-		NewConnection(string, reader.Reader) (Dumper, error)
+		NewConnection(ConnectionOpts, reader.Reader) (Dumper, error)
 	}
 
 	// A Dumper writes a database's stucture to the provided stream.
@@ -20,18 +22,27 @@ type (
 		// Close closes the dumper resources and releases them.
 		Close() error
 	}
+
+	// ConnectionOpts are the options to create a connection
+	ConnectionOpts struct {
+		DSN                string
+		Timeout            time.Duration
+		MaxConnLifetime    time.Duration
+		MaxConnections     int
+		MaxIdleConnections int
+	}
 )
 
 // NewDumper is a factory method that will create a dumper based on the provided DSN
-func NewDumper(dsn string, rdr reader.Reader) (dumper Dumper, err error) {
+func NewDumper(opts ConnectionOpts, rdr reader.Reader) (dumper Dumper, err error) {
 	drivers.Range(func(key, value interface{}) bool {
 		driver, ok := value.(Driver)
-		if !ok || !driver.IsSupported(dsn) {
+		if !ok || !driver.IsSupported(opts.DSN) {
 			return true
 		}
 		log.WithField("driver", key).Debug("Found driver")
 
-		dumper, err = driver.NewConnection(dsn, rdr)
+		dumper, err = driver.NewConnection(opts, rdr)
 		return false
 	})
 
@@ -39,7 +50,7 @@ func NewDumper(dsn string, rdr reader.Reader) (dumper Dumper, err error) {
 		err = errors.New("no supported driver found")
 	}
 
-	err = errors.Wrapf(err, "could not create dumper for dsn: '%v'", dsn)
+	err = errors.Wrapf(err, "could not create dumper for dsn: '%v'", opts.DSN)
 
 	return
 }

--- a/pkg/dumper/mysql/mysql.go
+++ b/pkg/dumper/mysql/mysql.go
@@ -20,8 +20,8 @@ func (m *driver) IsSupported(dsn string) bool {
 	return err == nil
 }
 
-func (m *driver) NewConnection(dsn string, rdr reader.Reader) (dumper.Dumper, error) {
-	dsnCfg, err := mysql.ParseDSN(dsn)
+func (m *driver) NewConnection(opts dumper.ConnectionOpts, rdr reader.Reader) (dumper.Dumper, error) {
+	dsnCfg, err := mysql.ParseDSN(opts.DSN)
 	if err != nil {
 		return nil, err
 	}
@@ -35,6 +35,10 @@ func (m *driver) NewConnection(dsn string, rdr reader.Reader) (dumper.Dumper, er
 	if err != nil {
 		return nil, err
 	}
+
+	conn.SetMaxOpenConns(opts.MaxConnections)
+	conn.SetMaxIdleConns(opts.MaxIdleConnections)
+	conn.SetConnMaxLifetime(opts.MaxConnLifetime)
 
 	return NewDumper(conn, rdr), nil
 }

--- a/pkg/dumper/postgres/postgres.go
+++ b/pkg/dumper/postgres/postgres.go
@@ -14,11 +14,15 @@ func (m *driver) IsSupported(dsn string) bool {
 	return strings.HasPrefix(strings.ToLower(dsn), "postgres://")
 }
 
-func (m *driver) NewConnection(dsn string, rdr reader.Reader) (dumper.Dumper, error) {
-	conn, err := sql.Open("postgres", dsn)
+func (m *driver) NewConnection(opts dumper.ConnectionOpts, rdr reader.Reader) (dumper.Dumper, error) {
+	conn, err := sql.Open("postgres", opts.DSN)
 	if err != nil {
 		return nil, err
 	}
+
+	conn.SetMaxOpenConns(opts.MaxConnections)
+	conn.SetMaxIdleConns(opts.MaxIdleConnections)
+	conn.SetConnMaxLifetime(opts.MaxConnLifetime)
 
 	return NewDumper(conn, rdr), nil
 }

--- a/pkg/dumper/query/query.go
+++ b/pkg/dumper/query/query.go
@@ -16,8 +16,8 @@ func (m *driver) IsSupported(dsn string) bool {
 	return d.Type == "os"
 }
 
-func (m *driver) NewConnection(dsn string, rdr reader.Reader) (dumper.Dumper, error) {
-	writer, err := getOutputWriter(dsn)
+func (m *driver) NewConnection(opts dumper.ConnectionOpts, rdr reader.Reader) (dumper.Dumper, error) {
+	writer, err := getOutputWriter(opts.DSN)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reader/mysql/mysql.go
+++ b/pkg/reader/mysql/mysql.go
@@ -18,11 +18,15 @@ func (m *driver) IsSupported(dsn string) bool {
 	return err == nil
 }
 
-func (m *driver) NewConnection(dsn string) (reader.Reader, error) {
-	conn, err := sql.Open("mysql", dsn)
+func (m *driver) NewConnection(opts reader.ConnectionOpts) (reader.Reader, error) {
+	conn, err := sql.Open("mysql", opts.DSN)
 	if err != nil {
 		return nil, err
 	}
+
+	conn.SetMaxOpenConns(opts.MaxConnections)
+	conn.SetMaxIdleConns(opts.MaxIdleConnections)
+	conn.SetConnMaxLifetime(opts.MaxConnLifetime)
 
 	return NewStorage(conn), nil
 }

--- a/pkg/reader/postgres/postgres.go
+++ b/pkg/reader/postgres/postgres.go
@@ -14,13 +14,17 @@ func (m *driver) IsSupported(dsn string) bool {
 	return strings.HasPrefix(strings.ToLower(dsn), "postgres://")
 }
 
-func (m *driver) NewConnection(dsn string) (reader.Reader, error) {
-	conn, err := sql.Open("postgres", dsn)
+func (m *driver) NewConnection(opts reader.ConnectionOpts) (reader.Reader, error) {
+	conn, err := sql.Open("postgres", opts.DSN)
 	if err != nil {
 		return nil, err
 	}
 
-	dump, err := NewPgDump(dsn)
+	conn.SetMaxOpenConns(opts.MaxConnections)
+	conn.SetMaxIdleConns(opts.MaxIdleConnections)
+	conn.SetConnMaxLifetime(opts.MaxConnLifetime)
+
+	dump, err := NewPgDump(opts.DSN)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added new flags:

```
    --conn-lifetime string   Sets the maximum amount of time a connection may be reused (default "0")
  -m, --max-conns int          Sets the maximum number of open connections to the database (default 10)
  -i, --max-idle-conns int     Sets the maximum number of connections in the idle connection pool
      --timeout string         Sets the timeout for all the operations (default "30s")
```