### PR TITLE
Fix relationships 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,79 @@ All you need to have is a simple configuration file where you're going to define
 
 Here is an example of how the config file should look like:
 
+Dump all users based on the `match` field and use it for dumping their related orders:
 ```toml
 [[Tables]]
-  Name = "orders"
+  # Dump only matching users
+  Name = "users"
   [Tables.Filter]
-    Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
-    Limit = 100
+    # Behind the scenes it will generate the following sql query:
+    # SELECT users.* FROM users
+    # WHERE users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')
+		Match = "users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')"
 
 [[Tables]]
-  Name = "customers"
+  # Dump only orders which are related to the matching users
+  Name = "orders"
   [Tables.Filter]
-    Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
-    Limit = 100
+    # Behind the scenes it will generate the following sql query:
+    # SELECT orders.* FROM orders
+    # JOIN users ON orders.user_id = users.id
+    # WHERE users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')
+    # GROUP BY orders.id
+		Match = "users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')"
   [[Tables.Relationships]]
-    ReferencedTable = "customers"
+    ReferencedTable = "users"
     ReferencedKey = "id"
-    ForeignKey = "customer_id"
+    ForeignKey = "user_id"
 ```
 
-In this example it will dump 100 orders with creation date greater or equal than `2018-01-01` and all customers related to these orders.
+Additionally you can dump all orders based on the `match` field and use it for dumping all related users:
+```toml
+[[Tables]]
+  # Dump only matching orders
+  Name = "orders"
+  [Tables.Filter]
+    # Behind the scenes it will generate the following query:
+    # SELECT orders.* FROM orders
+    # WHERE orders.created_at BETWEEN '2018-01-01' AND now()
+		Match = "orders.created_at BETWEEN '2018-01-01' AND now()"
 
-After you have this, just run:
+[[Tables]]
+  # Dump only users which are related to the orders
+  Name = "users"
+  [Tables.Filter]
+    # Behind the scenes it will generate the following query:
+    # SELECT users.* FROM users
+    # JOIN orders ON users.id = orders.user_id
+    # WHERE orders.created_at BETWEEN '2018-01-01' AND now()
+    # GROUP BY users.id
+    Match = "orders.created_at BETWEEN '2018-01-01' AND now()"
+  [[Tables.Relationships]]
+    ReferencedTable = "users"
+    ReferencedKey = "id"
+    ForeignKey = "user_id"
+```
 
+After you have created the file just run:
+
+Postgres:
 ```sh
-klepto steal --from 'postgres://root:root@localhost:8050/fromDB?sslmode=disable' --to 'postgres://root:root@localhost:8050/toDB?sslmode=disable'
+go run main.go steal \
+--from="postgres://user:pass@localhost/fromDB?sslmode=disable" \
+--to="postgres://user:pass@localhost/toDB?sslmode=disable" \
+--concurrency=6 \
+--read-max-conns=10 \
+--read-max-idle-conns=4
+```
+
+MySQL:
+```sh
+klepto steal \
+--from 'user:pass@tcp(localhost:3306)/fromDB?sslmode=disable' \
+--to 'user:pass@tcp(localhost:3306)/toDB?sslmode=disable' \
+--concurrency=4 \
+--read-max-conns=8
 ```
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Here is an example of how the config file should look like:
 [[Tables]]
   Name = "orders"
   [Tables.Filter]
-		Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
+    Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
     Limit = 100
 
 [[Tables]]
   Name = "customers"
   [Tables.Filter]
-		Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
+    Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
     Limit = 100
   [[Tables.Relationships]]
     ReferencedTable = "customers"

--- a/README.md
+++ b/README.md
@@ -17,18 +17,21 @@ Here is an example of how the config file should look like:
 [[Tables]]
   Name = "orders"
   [Tables.Filter]
+		Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
     Limit = 100
-    [Tables.Filter.Sorts]
-      orderNr = "asc"
-  [Tables.Anonymise]
-    email = "EmailAddress"
-    firstName = "FirstName"
 
+[[Tables]]
+  Name = "customers"
+  [Tables.Filter]
+		Match = "orders.createdat BETWEEN '2018-02-01' AND now()"
+    Limit = 100
   [[Tables.Relationships]]
     ReferencedTable = "customers"
     ReferencedKey = "id"
     ForeignKey = "customer_id"
 ```
+
+In this example it will dump 100 orders with creation date greater or equal than `2018-01-01` and all customers related to these orders.
 
 After you have this, just run:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ After you have created the file just run:
 
 Postgres:
 ```sh
-go run main.go steal \
+klepto steal \
 --from="postgres://user:pass@localhost/fromDB?sslmode=disable" \
 --to="postgres://user:pass@localhost/toDB?sslmode=disable" \
 --concurrency=6 \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dump all users based on the `match` field and use it for dumping their related o
     # Behind the scenes it will generate the following sql query:
     # SELECT users.* FROM users
     # WHERE users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')
-		Match = "users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')"
+    Match = "users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')"
 
 [[Tables]]
   # Dump only orders which are related to the matching users
@@ -33,7 +33,7 @@ Dump all users based on the `match` field and use it for dumping their related o
     # JOIN users ON orders.user_id = users.id
     # WHERE users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')
     # GROUP BY orders.id
-		Match = "users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')"
+    Match = "users.id IN ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', '66a45c1b-19af-4ab5-8747-1b0e2d79339d')"
   [[Tables.Relationships]]
     ReferencedTable = "users"
     ReferencedKey = "id"
@@ -49,7 +49,7 @@ Additionally you can dump all orders based on the `match` field and use it for d
     # Behind the scenes it will generate the following query:
     # SELECT orders.* FROM orders
     # WHERE orders.created_at BETWEEN '2018-01-01' AND now()
-		Match = "orders.created_at BETWEEN '2018-01-01' AND now()"
+    Match = "orders.created_at BETWEEN '2018-01-01' AND now()"
 
 [[Tables]]
   # Dump only users which are related to the orders

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -39,17 +39,24 @@ func RunInit() {
 	err = e.Encode(config.Spec{
 		Tables: []*config.Table{
 			{
-				Name: "orders",
+				Name: "users",
 				Filter: config.Filter{
-					Limit: 100,
+					Match: "users.active = TRUE",
 					Sorts: map[string]string{"orderNr": "asc"},
+					Limit: 100,
 				},
 				Anonymise: map[string]string{"firstName": "FirstName", "email": "EmailAddress"},
+			},
+			{
+				Name: "orders",
+				Filter: config.Filter{
+					Match: "users.active = TRUE",
+				},
 				Relationships: []*config.Relationship{
 					{
-						ReferencedTable: "customers",
+						ReferencedTable: "users",
 						ReferencedKey:   "id",
-						ForeignKey:      "customer_id",
+						ForeignKey:      "user_id",
 					},
 				},
 			},

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -51,6 +51,7 @@ func RunInit() {
 				Name: "orders",
 				Filter: config.Filter{
 					Match: "users.active = TRUE",
+					Limit: 10,
 				},
 				Relationships: []*config.Relationship{
 					{

--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -20,10 +20,11 @@ import (
 // StealOptions represents the command options
 type (
 	StealOptions struct {
-		from      string
-		to        string
-		readOpts  connOpts
-		writeOpts connOpts
+		from        string
+		to          string
+		concurrency int
+		readOpts    connOpts
+		writeOpts   connOpts
 	}
 	connOpts struct {
 		timeout         string
@@ -48,18 +49,15 @@ func NewStealCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&opts.from, "from", "f", "root:root@tcp(localhost:3306)/klepto", "Database dsn to steal from")
 	cmd.PersistentFlags().StringVarP(&opts.to, "to", "t", "os://stdout/", "Database to output to (default writes to stdOut)")
-
+	cmd.PersistentFlags().IntVar(&opts.concurrency, "concurrency", 4, "Sets the amount of dumps to be performed concurrently")
 	cmd.PersistentFlags().StringVar(&opts.readOpts.timeout, "read-timeout", "30s", "Sets the timeout for all read operations")
 	cmd.PersistentFlags().StringVar(&opts.writeOpts.timeout, "write-timeout", "30s", "Sets the timeout for all write operations")
-
 	cmd.PersistentFlags().StringVar(&opts.readOpts.maxConnLifetime, "read-conn-lifetime", "0", "Sets the maximum amount of time a connection may be reused on the read database")
 	cmd.PersistentFlags().IntVar(&opts.readOpts.maxConns, "read-max-conns", 10, "Sets the maximum number of open connections to the read database")
 	cmd.PersistentFlags().IntVar(&opts.readOpts.maxIdleConns, "read-max-idle-conns", 0, "Sets the maximum number of connections in the idle connection pool for the read database")
-
 	cmd.PersistentFlags().StringVar(&opts.writeOpts.maxConnLifetime, "write-conn-lifetime", "0", "Sets the maximum amount of time a connection may be reused on the write database")
 	cmd.PersistentFlags().IntVar(&opts.writeOpts.maxConns, "write-max-conns", 10, "Sets the maximum number of open connections to the write database")
 	cmd.PersistentFlags().IntVar(&opts.writeOpts.maxIdleConns, "write-max-idle-conns", 0, "Sets the maximum number of connections in the idle connection pool for the write database")
-
 	return cmd
 }
 
@@ -103,7 +101,7 @@ func RunSteal(opts *StealOptions) (err error) {
 	done := make(chan struct{})
 	defer close(done)
 	start := time.Now()
-	failOnError(target.Dump(done, globalConfig.Tables), "Error while dumping")
+	failOnError(target.Dump(done, globalConfig.Tables, opts.concurrency), "Error while dumping")
 
 	<-done
 	log.WithField("total_time", time.Since(start)).Info("Done!")

--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -102,10 +102,11 @@ func RunSteal(opts *StealOptions) (err error) {
 
 	done := make(chan struct{})
 	defer close(done)
+	start := time.Now()
 	failOnError(target.Dump(done, globalConfig.Tables), "Error while dumping")
 
 	<-done
-	log.Info("Done!")
+	log.WithField("total_time", time.Since(start)).Info("Done!")
 
 	return nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       POSTGRES_DB: klepto
 
   mysql_source:
-    image: mysql:5.5
+    image: mysql:5.6
     ports:
       - '8052:3306'
     environment:
@@ -40,7 +40,7 @@ services:
       - ./fixtures/mysql_simple.sql:/docker-entrypoint-initdb.d/init.sql
 
   mysql_target:
-    image: mysql:5.5
+    image: mysql:5.6
     ports:
       - '8053:3306'
     environment:

--- a/features/mysql_test.go
+++ b/features/mysql_test.go
@@ -46,7 +46,7 @@ func (s *MysqlTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, config.Tables{}), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, config.Tables{}, 4), "Failed to dump")
 
 	<-done
 

--- a/features/postgres_test.go
+++ b/features/postgres_test.go
@@ -54,7 +54,7 @@ func (s *PostgresTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, config.Tables{}), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, config.Tables{}, 4), "Failed to dump")
 
 	<-done
 

--- a/fixtures/mysql_simple.sql
+++ b/fixtures/mysql_simple.sql
@@ -5,24 +5,27 @@ CREATE TABLE users
   email varchar(255) NOT NULL,
   active tinyint(1) NOT NULL,
   gender char(1)
+  created_at timestamp
 );
 
 CREATE TABLE orders
 (
   id varchar(36) PRIMARY KEY NOT NULL,
   user_id varchar(36) NOT NULL,
+  created_at timestamp
   CONSTRAINT orders_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id)
 );
 
-INSERT INTO `users` VALUES ('0d60a85e-0b90-4482-a14c-108aea2557aa', 'wbo', 'wbo@hellofresh.com', true, 'm');
-INSERT INTO `users` VALUES ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', 'kp', 'kp@hellofresh.com', true, NULL);
-INSERT INTO `users` VALUES ('9e4de779-d6a0-44bc-a531-20cdb97178d2', 'lp', 'lp@hellofresh.com', false, 'f');
-INSERT INTO `users` VALUES ('66a45c1b-19af-4ab5-8747-1b0e2d79339d', 'il', 'il@hellofresh.com', true, 'm');
+INSERT INTO `users` VALUES ('0d60a85e-0b90-4482-a14c-108aea2557aa', 'wbo', 'wbo@hellofresh.com', true, 'm', '2017-01-01');
+INSERT INTO `users` VALUES ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', 'kp', 'kp@hellofresh.com', true, NULL, '2017-01-01');
+INSERT INTO `users` VALUES ('9e4de779-d6a0-44bc-a531-20cdb97178d2', 'lp', 'lp@hellofresh.com', false, 'f', '2017-01-01');
+INSERT INTO `users` VALUES ('66a45c1b-19af-4ab5-8747-1b0e2d79339d', 'il', 'il@hellofresh.com', true, 'm', '2017-01-01');
 
-INSERT INTO `orders` VALUES ('b9bcd5e1-75e6-412d-be87-278003519717', '66a45c1b-19af-4ab5-8747-1b0e2d79339d');
-INSERT INTO `orders` VALUES ('7ee31a7f-5140-483b-8ba1-fa8f116219c0', '66a45c1b-19af-4ab5-8747-1b0e2d79339d');
-INSERT INTO `orders` VALUES ('dda290ff-6243-46d9-83cb-acbad41e936e', '66a45c1b-19af-4ab5-8747-1b0e2d79339d');
-INSERT INTO `orders` VALUES ('453f4498-b4e0-485f-94fa-72f233bb7958', '9e4de779-d6a0-44bc-a531-20cdb97178d2');
-INSERT INTO `orders` VALUES ('8bdf39d8-616c-45d4-826f-bad30cb4e1a3', '9e4de779-d6a0-44bc-a531-20cdb97178d2');
-INSERT INTO `orders` VALUES ('f1f7c9c7-bdb7-4626-a5c9-44d8942e52dd', '39240e9f-ae09-4e95-9fd0-a712035c8ad7');
-INSERT INTO `orders` VALUES ('e650ad64-f1e4-4f91-abea-ec1a70992926', '39240e9f-ae09-4e95-9fd0-a712035c8ad7');
+INSERT INTO `orders` VALUES ('b9bcd5e1-75e6-412d-be87-278003519717', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2018-01-01');
+INSERT INTO `orders` VALUES ('7ee31a7f-5140-483b-8ba1-fa8f116219c0', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2018-01-01');
+INSERT INTO `orders` VALUES ('dda290ff-6243-46d9-83cb-acbad41e936e', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2018-01-01');
+INSERT INTO `orders` VALUES ('453f4498-b4e0-485f-94fa-72f233bb7958', '9e4de779-d6a0-44bc-a531-20cdb97178d2', '2018-01-01');
+INSERT INTO `orders` VALUES ('8bdf39d8-616c-45d4-826f-bad30cb4e1a3', '9e4de779-d6a0-44bc-a531-20cdb97178d2', '2018-01-01');
+INSERT INTO `orders` VALUES ('f1f7c9c7-bdb7-4626-a5c9-44d8942e52dd', '39240e9f-ae09-4e95-9fd0-a712035c8ad7', '2018-01-01');
+INSERT INTO `orders` VALUES ('e650ad64-f1e4-4f91-abea-ec1a70992926', '39240e9f-ae09-4e95-9fd0-a712035c8ad7', '2018-01-01');
+INSERT INTO `orders` VALUES ('2b92734e-0e4c-11e8-ba89-0ed5f89f718b', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2017-01-01');

--- a/fixtures/mysql_simple.sql
+++ b/fixtures/mysql_simple.sql
@@ -4,7 +4,7 @@ CREATE TABLE users
   username varchar(50) NOT NULL,
   email varchar(255) NOT NULL,
   active tinyint(1) NOT NULL,
-  gender char(1)
+  gender char(1),
   created_at timestamp
 );
 
@@ -12,7 +12,7 @@ CREATE TABLE orders
 (
   id varchar(36) PRIMARY KEY NOT NULL,
   user_id varchar(36) NOT NULL,
-  created_at timestamp
+  created_at timestamp,
   CONSTRAINT orders_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id)
 );
 

--- a/fixtures/pg_simple.sql
+++ b/fixtures/pg_simple.sql
@@ -3,32 +3,34 @@
 --
 
 CREATE TABLE "users" (
-    id UUID PRIMARY KEY NOT NULL,
-    username character varying(50) NOT NULL,
-    email character varying(255) NOT NULL,
-    active boolean NOT NULL,
-    gender character(1)
+  id UUID PRIMARY KEY NOT NULL,
+  username character varying(50) NOT NULL,
+  email character varying(255) NOT NULL,
+  active boolean NOT NULL,
+  gender character(1)
+  created_at timestamp
 );
 
 CREATE TABLE "orders" (
-    id UUID PRIMARY KEY NOT NULL,
-    user_id UUID NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id)
+  id UUID PRIMARY KEY NOT NULL,
+  user_id UUID NOT NULL,
+  created_at timestamp
+  FOREIGN KEY (user_id) REFERENCES users(id)
 );
 
-INSERT INTO "users" VALUES ('0d60a85e-0b90-4482-a14c-108aea2557aa', 'wbo', 'wbo@hellofresh.com', true, 'm');
-INSERT INTO "users" VALUES ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', 'kp', 'kp@hellofresh.com', true, NULL);
-INSERT INTO "users" VALUES ('9e4de779-d6a0-44bc-a531-20cdb97178d2', 'lp', 'lp@hellofresh.com', false, 'f');
-INSERT INTO "users" VALUES ('66a45c1b-19af-4ab5-8747-1b0e2d79339d', 'il', 'il@hellofresh.com', true, 'm');
+INSERT INTO "users" VALUES ('0d60a85e-0b90-4482-a14c-108aea2557aa', 'wbo', 'wbo@hellofresh.com', true, 'm', '2017-01-01');
+INSERT INTO "users" VALUES ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', 'kp', 'kp@hellofresh.com', true, NULL, '2017-01-01');
+INSERT INTO "users" VALUES ('9e4de779-d6a0-44bc-a531-20cdb97178d2', 'lp', 'lp@hellofresh.com', false, 'f', '2017-01-01');
+INSERT INTO "users" VALUES ('66a45c1b-19af-4ab5-8747-1b0e2d79339d', 'il', 'il@hellofresh.com', true, 'm', '2017-01-01');
 
-INSERT INTO "orders" VALUES ('b9bcd5e1-75e6-412d-be87-278003519717', '66a45c1b-19af-4ab5-8747-1b0e2d79339d');
-INSERT INTO "orders" VALUES ('7ee31a7f-5140-483b-8ba1-fa8f116219c0', '66a45c1b-19af-4ab5-8747-1b0e2d79339d');
-INSERT INTO "orders" VALUES ('dda290ff-6243-46d9-83cb-acbad41e936e', '66a45c1b-19af-4ab5-8747-1b0e2d79339d');
-INSERT INTO "orders" VALUES ('453f4498-b4e0-485f-94fa-72f233bb7958', '9e4de779-d6a0-44bc-a531-20cdb97178d2');
-INSERT INTO "orders" VALUES ('8bdf39d8-616c-45d4-826f-bad30cb4e1a3', '9e4de779-d6a0-44bc-a531-20cdb97178d2');
-INSERT INTO "orders" VALUES ('f1f7c9c7-bdb7-4626-a5c9-44d8942e52dd', '39240e9f-ae09-4e95-9fd0-a712035c8ad7');
-INSERT INTO "orders" VALUES ('e650ad64-f1e4-4f91-abea-ec1a70992926', '39240e9f-ae09-4e95-9fd0-a712035c8ad7');
-
+INSERT INTO "orders" VALUES ('b9bcd5e1-75e6-412d-be87-278003519717', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2018-01-01');
+INSERT INTO "orders" VALUES ('7ee31a7f-5140-483b-8ba1-fa8f116219c0', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2018-01-01');
+INSERT INTO "orders" VALUES ('dda290ff-6243-46d9-83cb-acbad41e936e', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2018-01-01');
+INSERT INTO "orders" VALUES ('453f4498-b4e0-485f-94fa-72f233bb7958', '9e4de779-d6a0-44bc-a531-20cdb97178d2', '2018-01-01');
+INSERT INTO "orders" VALUES ('8bdf39d8-616c-45d4-826f-bad30cb4e1a3', '9e4de779-d6a0-44bc-a531-20cdb97178d2', '2018-01-01');
+INSERT INTO "orders" VALUES ('f1f7c9c7-bdb7-4626-a5c9-44d8942e52dd', '39240e9f-ae09-4e95-9fd0-a712035c8ad7', '2018-01-01');
+INSERT INTO "orders" VALUES ('e650ad64-f1e4-4f91-abea-ec1a70992926', '39240e9f-ae09-4e95-9fd0-a712035c8ad7', '2018-01-01');
+INSERT INTO "orders" VALUES ('2b92734e-0e4c-11e8-ba89-0ed5f89f718b', '66a45c1b-19af-4ab5-8747-1b0e2d79339d', '2017-01-01');
 --
 -- PostgreSQL database dump complete
 --

--- a/fixtures/pg_simple.sql
+++ b/fixtures/pg_simple.sql
@@ -7,14 +7,14 @@ CREATE TABLE "users" (
   username character varying(50) NOT NULL,
   email character varying(255) NOT NULL,
   active boolean NOT NULL,
-  gender character(1)
+  gender character(1),
   created_at timestamp
 );
 
 CREATE TABLE "orders" (
   id UUID PRIMARY KEY NOT NULL,
   user_id UUID NOT NULL,
-  created_at timestamp
+  created_at timestamp,
   FOREIGN KEY (user_id) REFERENCES users(id)
 );
 

--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -19,6 +19,7 @@ const (
 	literalPrefix = "literal:"
 	email         = "EmailAddress"
 	username      = "UserName"
+	password      = "Password"
 )
 
 // anonymiser is responsible for anonymising columns
@@ -69,19 +70,20 @@ func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 						continue
 					}
 
-					hash := ""
-					// check if the anonymised value should be uniq
-					if a.uniq(name) {
+					var value string
+					switch name {
+					case email, username:
 						b := make([]byte, 2)
 						rand.Read(b)
-						hash = hex.EncodeToString(b)
+						value = fmt.Sprintf(
+							"%s.%s",
+							faker.Call([]reflect.Value{})[0].String(),
+							hex.EncodeToString(b),
+						)
+					default:
+						value = faker.Call([]reflect.Value{})[0].String()
 					}
-
-					row[column] = fmt.Sprintf(
-						"%s.%s",
-						faker.Call([]reflect.Value{})[0].String(),
-						hash,
-					)
+					row[column] = value
 				}
 			}
 
@@ -94,8 +96,4 @@ func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 	}
 
 	return nil
-}
-
-func (a *anonymiser) uniq(column string) bool {
-	return column == email || column == username
 }

--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -21,30 +21,30 @@ const (
 	username      = "UserName"
 )
 
-// Anonymiser is responsible for anonymising columns
-type Anonymiser struct {
-	reader reader.Reader
+// anonymiser is responsible for anonymising columns
+type anonymiser struct {
+	reader.Reader
 	tables config.Tables
 }
 
 // NewAnonymiser returns an initialised instance of MySQLAnonymiser
-func NewAnonymiser(source reader.Reader, tables config.Tables) *Anonymiser {
-	return &Anonymiser{source, tables}
+func NewAnonymiser(source reader.Reader, tables config.Tables) reader.Reader {
+	return &anonymiser{source, tables}
 }
 
 // ReadTable wraps reader.ReadTable method for anonymising rows published from the reader.Reader
-func (a *Anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt, configTables config.Tables) error {
+func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt, configTables config.Tables) error {
 	logger := log.WithField("table", tableName)
 	logger.Debug("Loading anonymiser config")
 	table, err := a.tables.FindByName(tableName)
 	if err != nil {
 		logger.WithError(err).Debug("the table is not configured to be anonymised")
-		return a.reader.ReadTable(tableName, rowChan, opts, configTables)
+		return a.Reader.ReadTable(tableName, rowChan, opts, configTables)
 	}
 
 	if len(table.Anonymise) == 0 {
 		logger.Debug("Skipping anonymiser")
-		return a.reader.ReadTable(tableName, rowChan, opts, configTables)
+		return a.Reader.ReadTable(tableName, rowChan, opts, configTables)
 	}
 
 	// Create read/write chanel
@@ -89,13 +89,13 @@ func (a *Anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 		}
 	}(rowChan, rawChan, table)
 
-	if err := a.reader.ReadTable(tableName, rawChan, opts, configTables); err != nil {
+	if err := a.Reader.ReadTable(tableName, rawChan, opts, configTables); err != nil {
 		return errors.Wrap(err, "anonymiser: error while reading table")
 	}
 
 	return nil
 }
 
-func (a *Anonymiser) uniq(column string) bool {
+func (a *anonymiser) uniq(column string) bool {
 	return column == email || column == username
 }

--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -14,8 +14,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// literalPrefix defines the constant we use to prefix literals
-const literalPrefix = "literal:"
+const (
+	// literalPrefix defines the constant we use to prefix literals
+	literalPrefix = "literal:"
+	email         = "EmailAddress"
+	username      = "UserName"
+)
 
 // Anonymiser is responsible for anonymising columns
 type Anonymiser struct {
@@ -65,12 +69,18 @@ func (a *Anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 						continue
 					}
 
-					b := make([]byte, 2)
-					rand.Read(b)
+					hash := ""
+					// check if the anonymised value should be uniq
+					if a.uniq(name) {
+						b := make([]byte, 2)
+						rand.Read(b)
+						hash = hex.EncodeToString(b)
+					}
+
 					row[column] = fmt.Sprintf(
 						"%s.%s",
 						faker.Call([]reflect.Value{})[0].String(),
-						hex.EncodeToString(b),
+						hash,
 					)
 				}
 			}
@@ -84,4 +94,8 @@ func (a *Anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 	}
 
 	return nil
+}
+
+func (a *Anonymiser) uniq(column string) bool {
+	return column == email || column == username
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ type (
 
 	// Filter represents the way you want to filter the results
 	Filter struct {
+		Match string
 		Limit uint64
 		Sorts map[string]string
 	}

--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -18,7 +18,7 @@ type (
 
 	// A Dumper writes a database's stucture to the provided stream.
 	Dumper interface {
-		Dump(chan<- struct{}, config.Tables) error
+		Dump(chan<- struct{}, config.Tables, int) error
 		// Close closes the dumper resources and releases them.
 		Close() error
 	}

--- a/pkg/dumper/postgres/dumper.go
+++ b/pkg/dumper/postgres/dumper.go
@@ -105,6 +105,7 @@ func (p *pgDumper) insertIntoTable(txn *sql.Tx, tableName string, rowChan <-chan
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to prepare copy in")
 	}
+
 	defer func() {
 		if err = stmt.Close(); err != nil {
 			log.WithError(err).Error("failed to close copy in statement")

--- a/pkg/dumper/query/dumper.go
+++ b/pkg/dumper/query/dumper.go
@@ -78,7 +78,7 @@ func (d *textDumper) Dump(done chan<- struct{}, configTables config.Tables) erro
 			}
 		}(tbl)
 
-		if err := d.reader.ReadTable(tbl, rowChan, opts); err != nil {
+		if err := d.reader.ReadTable(tbl, rowChan, opts, configTables); err != nil {
 			log.WithError(err).WithField("table", tbl).Error("error while reading table")
 		}
 	}

--- a/pkg/dumper/query/dumper.go
+++ b/pkg/dumper/query/dumper.go
@@ -29,7 +29,7 @@ func NewDumper(output io.Writer, rdr reader.Reader) dumper.Dumper {
 	}
 }
 
-func (d *textDumper) Dump(done chan<- struct{}, configTables config.Tables) error {
+func (d *textDumper) Dump(done chan<- struct{}, configTables config.Tables, concurrency int) error {
 	tables, err := d.reader.GetTables()
 	if err != nil {
 		return errors.Wrap(err, "could not get tables")

--- a/pkg/reader/generic/sql.go
+++ b/pkg/reader/generic/sql.go
@@ -119,7 +119,6 @@ func (s *SqlReader) buildQuery(tableName string, opts reader.ReadTableOpt, confi
 
 	query = sq.Select(opts.Columns...).From(s.QuoteIdentifier(tableName))
 
-	// TODO do we support multiple relationships?
 	for _, r := range opts.Relationships {
 		query = query.Join(fmt.Sprintf(
 			"%s ON %s.%s = %s.%s",
@@ -128,7 +127,11 @@ func (s *SqlReader) buildQuery(tableName string, opts reader.ReadTableOpt, confi
 			r.ForeignKey,
 			r.ReferencedTable,
 			r.ReferencedKey,
-		)).GroupBy(fmt.Sprintf("%s.id", tableName))
+		))
+	}
+
+	if len(opts.Relationships) > 0 {
+		query = query.GroupBy(fmt.Sprintf("%s.id", tableName))
 	}
 
 	if opts.Match != "" {

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -34,7 +34,8 @@ type (
 	ReadTableOpt struct {
 		// Columns contains the (quoted) column of the table
 		Columns []string
-		Match   string
+		// Match is a condition field to dump only certain amount data
+		Match string
 		// Defines a limit of results to be fetched
 		Limit uint64
 		// Relationships defines an slice of relationship definitions

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -3,6 +3,7 @@ package reader
 import (
 	"time"
 
+	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/database"
 )
 
@@ -24,7 +25,7 @@ type (
 		// FormatColumn returns a escaped table.column string
 		FormatColumn(tableName string, columnName string) string
 		// ReadTable returns a channel with all database rows
-		ReadTable(string, chan<- database.Row, ReadTableOpt) error
+		ReadTable(string, chan<- database.Row, ReadTableOpt, config.Tables) error
 		// Close closes the reader resources and releases them.
 		Close() error
 	}
@@ -33,6 +34,7 @@ type (
 	ReadTableOpt struct {
 		// Columns contains the (quoted) column of the table
 		Columns []string
+		Match   string
 		// Defines a limit of results to be fetched
 		Limit uint64
 		// Relationships defines an slice of relationship definitions


### PR DESCRIPTION
This PR implements a new field `match`  which allows seamless dumping table based on the matching condition.

Here are some example of the matching conditions:
- `Match = "users.id IN (1, 2, 3)"`
- `Match = "users.id >= 500`
- `Match = "users.created_at BETWEEN '2018-01-01' AND now()`

The users -> orders sample could be mapped as follows:
```toml
[[Tables]]
  Name = "users"
  [Tables.Filter]
    Match = "users.created_at BETWEEN '2017-01-01' AND now()"

[[Tables]]
  Name = "orders"
  [Tables.Filter]
    Match = "users.created_at BETWEEN '2017-01-01' AND now()"
  [[Tables.Relationships]]
    ReferencedTable = "users"
    ReferencedKey = "id"
    ForeignKey = "user_id"
```