### PR TITLE
Add IgnoreData config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ By specifying anonymisation config in your `.klepto.toml` file, you can define w
 
 This would replace these 4 columns from the `customer` and `users` tables and run `faker.Email` and `faker.FirstName` against them respectively. We can use `literal:[some-constant-value]` to specify a constant we want to write for a column. In this case, `password: literal:1234` would write `1234` for every row in the password column of the customer table.
 
+## Ignore data
+
+Additionally you can dump the database structured without importing data
+```toml
+[[Tables]]
+ Name = "logs"
+ IgnoreData = true
+```
+
 ### Available data types for anonymisation
 
 Available data types can be found in [fake.go](pkg/anonymiser/fake.go). This file is generated from https://github.com/icrowley/fake (it must be generated because it is written in such a way that Go cannot reflect upon it).

--- a/README.md
+++ b/README.md
@@ -143,15 +143,6 @@ By specifying anonymisation config in your `.klepto.toml` file, you can define w
 
 This would replace these 4 columns from the `customer` and `users` tables and run `faker.Email` and `faker.FirstName` against them respectively. We can use `literal:[some-constant-value]` to specify a constant we want to write for a column. In this case, `password: literal:1234` would write `1234` for every row in the password column of the customer table.
 
-## Ignore data
-
-Additionally you can dump the database structured without importing data
-```toml
-[[Tables]]
- Name = "logs"
- IgnoreData = true
-```
-
 ### Available data types for anonymisation
 
 Available data types can be found in [fake.go](pkg/anonymiser/fake.go). This file is generated from https://github.com/icrowley/fake (it must be generated because it is written in such a way that Go cannot reflect upon it).
@@ -161,6 +152,15 @@ We generate the file with the following:
 ```sh
 $ go get github.com/ungerik/pkgreflect
 $ fake master pkgreflect -notypes -novars -norecurs vendor/github.com/icrowley/fake/
+```
+
+## Ignore data
+
+Additionally you can dump the database structure without importing data
+```toml
+[[Tables]]
+ Name = "logs"
+ IgnoreData = true
 ```
 
 ## Contributing

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -61,6 +61,10 @@ func RunInit() {
 					},
 				},
 			},
+			{
+				Name:       "logs",
+				IgnoreData: true,
+			},
 		},
 	})
 	failOnError(err, "Could not encode config")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ type (
 	// Table represents a klepto table definition
 	Table struct {
 		Name          string
+		IgnoreData    bool
 		Filter        Filter
 		Anonymise     map[string]string
 		Relationships []*Relationship

--- a/pkg/dumper/generic/sql.go
+++ b/pkg/dumper/generic/sql.go
@@ -105,14 +105,14 @@ func (p *sqlDumper) readAndDumpTables(done chan<- struct{}, configTables config.
 		semChan <- struct{}{}
 		wg.Add(1)
 
-		go func(tableName string, rowChan <-chan database.Row, semChan <-chan struct{}, logger *log.Entry) {
+		go func(tableName string, rowChan <-chan database.Row, logger *log.Entry) {
 			defer wg.Done()
 			defer func(semChan <-chan struct{}) { <-semChan }(semChan)
 
 			if err := p.DumpTable(tableName, rowChan); err != nil {
 				logger.WithError(err).Error("Failed to dump table")
 			}
-		}(tbl, rowChan, semChan, logger)
+		}(tbl, rowChan, logger)
 
 		go func(tableName string, opts reader.ReadTableOpt, rowChan chan<- database.Row, logger *log.Entry) {
 			if err := p.reader.ReadTable(tableName, rowChan, opts); err != nil {


### PR DESCRIPTION
This feature will allow users to dump the source database structure without importing data when the table has the following configuration:

```toml
[[Tables]]
  Name = "logs"
  IgnoreData = true
```