### PR TITLE
Introduce matchers configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,67 @@ klepto steal \
 MySQL:
 ```sh
 klepto steal \
---from 'user:pass@tcp(localhost:3306)/fromDB?sslmode=disable' \
---to 'user:pass@tcp(localhost:3306)/toDB?sslmode=disable' \
+--from="user:pass@tcp(localhost:3306)/fromDB?sslmode=disable" \
+--to="user:pass@tcp(localhost:3306)/toDB?sslmode=disable" \
 --concurrency=4 \
 --read-max-conns=8
+```
+
+## Relationships
+
+Dump the latest 100 users with their orders:
+```toml
+[[Tables]]
+  Name = "users"
+  [Tables.Filter]
+    Limit = 100
+    [Tables.Filter.Sorts]
+      created_at = "desc"
+
+[[Tables]]
+  Name = "orders"
+  [[Tables.Relationships]]
+    # behind the scenes klepto will create a inner join between orders and users
+    ForeignKey = "user_id"
+    ReferencedTable = "users"
+    ReferencedKey = "id"
+  [Tables.Filter]
+    Limit = 100
+    [Tables.Filter.Sorts]
+      created_at = "desc"
+```
+
+## Matchers
+
+You can declare a filter once and reuse it among tables:
+```toml
+[[Matchers]]
+  Latest100Users = "ORDER BY users.created_at DESC LIMIT 100"
+
+[[Tables]]
+  Name = "users"
+  [Tables.Filter]
+    Match = "Latest100Users"
+
+[[Tables]]
+  Name = "orders"
+  [[Tables.Relationships]]
+    ForeignKey = "user_id"
+    ReferencedTable = "users"
+    ReferencedKey = "id"
+  [Tables.Filter]
+    Match = "Latest100Users"
+```
+
+See [examples](./examples) for more.
+
+## Ignore data
+
+Additionally you can dump the database structure without importing data
+```toml
+[[Tables]]
+ Name = "logs"
+ IgnoreData = true
 ```
 
 ## Anonymisation
@@ -89,39 +146,6 @@ $ go get github.com/ungerik/pkgreflect
 $ fake master pkgreflect -notypes -novars -norecurs vendor/github.com/icrowley/fake/
 ```
 
-## Relationships
-
-Dump the latest 100 users with their orders:
-```toml
-[[Tables]]
-  Name = "users"
-  [Tables.Filter]
-    Limit = 100
-    [Tables.Filter.Sorts]
-      created_at = "desc"
-
-[[Tables]]
-  Name = "orders"
-  [[Tables.Relationships]]
-    ForeignKey = "user_id"
-    ReferencedTable = "users"
-    ReferencedKey = "id"
-  [Tables.Filter]
-    Limit = 100
-    [Tables.Filter.Sorts]
-      created_at = "desc"
-```
-
-See [examples](./examples) for more.
-
-## Ignore data
-
-Additionally you can dump the database structure without importing data
-```toml
-[[Tables]]
- Name = "logs"
- IgnoreData = true
-```
 
 ## Installing 
 

--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -101,7 +101,7 @@ func RunSteal(opts *StealOptions) (err error) {
 	done := make(chan struct{})
 	defer close(done)
 	start := time.Now()
-	failOnError(target.Dump(done, globalConfig.Tables, opts.concurrency), "Error while dumping")
+	failOnError(target.Dump(done, globalConfig, opts.concurrency), "Error while dumping")
 
 	<-done
 	log.WithField("total_time", time.Since(start)).Info("Done!")

--- a/examples/user-orders-using-matchers.toml
+++ b/examples/user-orders-using-matchers.toml
@@ -1,0 +1,49 @@
+[[Matchers]]
+  Latest100ActiveUsers = "users.active = true ORDER BY users.created_at DESC LIMIT 100"
+
+[[Tables]]
+  Name = "users"
+  [Tables.Anonymise]
+    email = "EmailAddress"
+    firstName = "FirstName"
+    password = "SimplePassword"
+  [Tables.Filter]
+    Match = "Latest100ActiveUsers"
+
+[[Tables]]
+  # Dump only orders which are related to the matching users
+  Name = "orders"
+  # Behind the scenes it will generate the following sql query:
+  # SELECT orders.* FROM orders
+  # JOIN users ON users.id = orders.user_id 
+  # WHERE users.status = 'active'
+  # ORDER BY created_at DESC
+  [[Tables.Relationships]]
+    Table = "orders"
+    ForeignKey = "user_id"
+    ReferencedTable = "users"
+    ReferencedKey = "id"
+  [Tables.Filter]
+    Match = "Latest100ActiveUsers"
+
+[[Tables]]
+  # Dump only order items which are related to the matching users orders
+  Name = "order_items"
+  # Behind the scenes it will generate the following sql query:
+  # SELECT order_items.* FROM order_items
+  # JOIN orders ON orders.id = order_items.order_id
+  # JOIN users ON users.id = orders.user_id 
+  # WHERE users.status = 'active'
+  # ORDER BY created_at DESC
+  [[Tables.Relationships]]
+    Table = "order_items"
+    ForeignKey = "order_id"
+    ReferencedTable = "orders"
+    ReferencedKey = "id"
+  [[Tables.Relationships]]
+    Table = "orders"
+    ForeignKey = "user_id"
+    ReferencedTable = "users"
+    ReferencedKey = "id"
+  [Tables.Filter]
+    Match = "Latest100ActiveUsers"

--- a/features/mysql_test.go
+++ b/features/mysql_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	_ "github.com/hellofresh/klepto/pkg/dumper/mysql"
 	"github.com/hellofresh/klepto/pkg/reader"
@@ -47,7 +46,7 @@ func (s *MysqlTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, config.Tables{}, 4), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, config, 4), "Failed to dump")
 
 	<-done
 

--- a/features/mysql_test.go
+++ b/features/mysql_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	_ "github.com/hellofresh/klepto/pkg/dumper/mysql"
 	"github.com/hellofresh/klepto/pkg/reader"
@@ -46,7 +47,7 @@ func (s *MysqlTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, config, 4), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, new(config.Spec), 4), "Failed to dump")
 
 	<-done
 

--- a/features/postgres_test.go
+++ b/features/postgres_test.go
@@ -12,7 +12,6 @@ import (
 
 	"strconv"
 
-	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	_ "github.com/hellofresh/klepto/pkg/dumper/postgres"
 	"github.com/hellofresh/klepto/pkg/reader"
@@ -55,7 +54,7 @@ func (s *PostgresTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, config.Tables{}, 4), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, 4), "Failed to dump")
 
 	<-done
 

--- a/features/postgres_test.go
+++ b/features/postgres_test.go
@@ -7,11 +7,11 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
-	"strconv"
-
+	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	_ "github.com/hellofresh/klepto/pkg/dumper/postgres"
 	"github.com/hellofresh/klepto/pkg/reader"
@@ -54,7 +54,7 @@ func (s *PostgresTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, 4), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, new(config.Spec), 4), "Failed to dump")
 
 	<-done
 

--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -34,18 +34,18 @@ func NewAnonymiser(source reader.Reader, tables config.Tables) reader.Reader {
 }
 
 // ReadTable wraps reader.ReadTable method for anonymising rows published from the reader.Reader
-func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt, matchers config.Matchers) error {
 	logger := log.WithField("table", tableName)
 	logger.Debug("Loading anonymiser config")
 	table, err := a.tables.FindByName(tableName)
 	if err != nil {
 		logger.WithError(err).Debug("the table is not configured to be anonymised")
-		return a.Reader.ReadTable(tableName, rowChan, opts)
+		return a.Reader.ReadTable(tableName, rowChan, opts, matchers)
 	}
 
 	if len(table.Anonymise) == 0 {
 		logger.Debug("Skipping anonymiser")
-		return a.Reader.ReadTable(tableName, rowChan, opts)
+		return a.Reader.ReadTable(tableName, rowChan, opts, matchers)
 	}
 
 	// Create read/write chanel
@@ -91,7 +91,7 @@ func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 		}
 	}(rowChan, rawChan, table)
 
-	if err := a.Reader.ReadTable(tableName, rawChan, opts); err != nil {
+	if err := a.Reader.ReadTable(tableName, rawChan, opts, matchers); err != nil {
 		return errors.Wrap(err, "anonymiser: error while reading table")
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,8 +5,13 @@ import "errors"
 type (
 	// Spec represents the global app configuration
 	Spec struct {
-		Tables Tables
+		Matchers
+		Tables
 	}
+
+	// Matchers are variables to replace placeolders in filter
+	Matchers map[string]string
+
 	// Tables are an array of table
 	Tables []*Table
 

--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -18,7 +18,7 @@ type (
 
 	// A Dumper writes a database's stucture to the provided stream.
 	Dumper interface {
-		Dump(chan<- struct{}, config.Tables, int) error
+		Dump(chan<- struct{}, *config.Spec, int) error
 		// Close closes the dumper resources and releases them.
 		Close() error
 	}

--- a/pkg/dumper/query/dumper.go
+++ b/pkg/dumper/query/dumper.go
@@ -29,7 +29,7 @@ func NewDumper(output io.Writer, rdr reader.Reader) dumper.Dumper {
 	}
 }
 
-func (d *textDumper) Dump(done chan<- struct{}, configTables config.Tables, concurrency int) error {
+func (d *textDumper) Dump(done chan<- struct{}, spec *config.Spec, concurrency int) error {
 	tables, err := d.reader.GetTables()
 	if err != nil {
 		return errors.Wrap(err, "could not get tables")
@@ -44,7 +44,7 @@ func (d *textDumper) Dump(done chan<- struct{}, configTables config.Tables, conc
 	for _, tbl := range tables {
 		var opts reader.ReadTableOpt
 
-		table, err := configTables.FindByName(tbl)
+		table, err := spec.Tables.FindByName(tbl)
 		if err != nil {
 			log.WithError(err).WithField("table", tbl).Debug("no configuration found for table")
 		}
@@ -78,7 +78,7 @@ func (d *textDumper) Dump(done chan<- struct{}, configTables config.Tables, conc
 			}
 		}(tbl)
 
-		if err := d.reader.ReadTable(tbl, rowChan, opts); err != nil {
+		if err := d.reader.ReadTable(tbl, rowChan, opts, spec.Matchers); err != nil {
 			log.WithError(err).WithField("table", tbl).Error("error while reading table")
 		}
 	}

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -3,6 +3,7 @@ package reader
 import (
 	"time"
 
+	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/database"
 )
 
@@ -24,7 +25,7 @@ type (
 		// FormatColumn returns a escaped table.column string
 		FormatColumn(tableName string, columnName string) string
 		// ReadTable returns a channel with all database rows
-		ReadTable(string, chan<- database.Row, ReadTableOpt) error
+		ReadTable(string, chan<- database.Row, ReadTableOpt, config.Matchers) error
 		// Close closes the reader resources and releases them.
 		Close() error
 	}


### PR DESCRIPTION
This PR introduces the new `Matchers` config, it will prevent users from having to repeat filters for every table