### PR TITLE
Ignore views

### DIFF
--- a/pkg/reader/postgres/reader.go
+++ b/pkg/reader/postgres/reader.go
@@ -36,7 +36,7 @@ func (s *storage) GetTables() ([]string, error) {
 	log.Debug("fetching table list")
 	rows, err := s.conn.Query(
 		`SELECT table_name FROM information_schema.tables
-		 WHERE table_catalog=current_database() AND table_schema NOT IN ('pg_catalog', 'information_schema')`,
+		 WHERE table_type='BASE TABLE' AND table_catalog=current_database() AND table_schema NOT IN ('pg_catalog', 'information_schema')`,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Small change to ignore views.

We have some views in our PostgreSQL database and without ignoring them, klepto fails to run. And anyways, copying data from views is more or less pointless as the data is anyways in other tables already.