### PR TITLE
PT-6669 Update Zappr config to not require qa and pm +1s

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,0 +1,6 @@
+approvals:
+  groups:
+    pm:
+      minimum: 0
+    qa:
+      minimum: 0


### PR DESCRIPTION
This PR adds a Zappr config to make `qa` and `pm` approvals optional