### PR TITLE
PT-6909 Apply matcher aliases to tables on config load 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can set a number of keys in the configuration file. Below is a list of all c
   - `Name` - The table name.
   - `IgnoreData` - A flag to indicate whether data should be imported or not. If set to true, it will dump the table structure without importing data.
   - `Filter` - A Klepto definition to filter results.
-    - `Match` - A condition field to dump only certain amount data. The value should correspond to an existing `Matchers` definition.
+    - `Match` - A condition field to dump only certain amount data. The value may be either expression or correspond to an existing `Matchers` definition.
     - `Limit` - The number of results to be fetched.
     - `Sorts` - Defines how the table is sorted.
   - `Anonymise` - Indicates which columns to anonymise.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"bufio"
 	"os"
 
-	"github.com/BurntSushi/toml"
 	wErrors "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -39,43 +37,8 @@ func RunInit() error {
 		return wErrors.Wrap(err, "could not create file")
 	}
 
-	e := toml.NewEncoder(bufio.NewWriter(f))
-	err = e.Encode(config.Spec{
-		Matchers: map[string]string{
-			"ActiveUsers": "users.active = TRUE",
-		},
-		Tables: []*config.Table{
-			{
-				Name: "users",
-				Filter: config.Filter{
-					Match: "users.active = TRUE",
-					Sorts: map[string]string{"user.id": "asc"},
-					Limit: 100,
-				},
-				Anonymise: map[string]string{"firstName": "FirstName", "email": "EmailAddress"},
-			},
-			{
-				Name: "orders",
-				Filter: config.Filter{
-					Match: "ActiveUsers",
-					Limit: 10,
-				},
-				Relationships: []*config.Relationship{
-					{
-						ReferencedTable: "users",
-						ReferencedKey:   "id",
-						ForeignKey:      "user_id",
-					},
-				},
-			},
-			{
-				Name:       "logs",
-				IgnoreData: true,
-			},
-		},
-	})
-	if err != nil {
-		return wErrors.Wrap(err, "could not encode config")
+	if err := config.WriteSample(f); err != nil {
+		return wErrors.Wrap(err, "could not write config")
 	}
 
 	log.Infof("Created %s!", config.DefaultConfigFileName)

--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -49,7 +49,7 @@ func NewStealCmd() *cobra.Command {
 		Short: "Steals and anonymises databases",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			opts.cfgTables, err = config.LoadSpecFromFile(opts.configPath)
+			opts.cfgTables, err = config.LoadFromFile(opts.configPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -25,7 +25,7 @@ type (
 	// StealOptions represents the command options
 	StealOptions struct {
 		configPath string
-		cfgSpec    *config.Spec
+		cfgTables  config.Tables
 
 		from        string
 		to          string
@@ -49,7 +49,7 @@ func NewStealCmd() *cobra.Command {
 		Short: "Steals and anonymises databases",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			opts.cfgSpec, err = config.LoadSpecFromFile(opts.configPath)
+			opts.cfgTables, err = config.LoadSpecFromFile(opts.configPath)
 			if err != nil {
 				return err
 			}
@@ -96,7 +96,7 @@ func RunSteal(opts *StealOptions) (err error) {
 		}
 	}()
 
-	source = anonymiser.NewAnonymiser(source, opts.cfgSpec.Tables)
+	source = anonymiser.NewAnonymiser(source, opts.cfgTables)
 	target, err := dumper.NewDumper(dumper.ConnOpts{
 		DSN:             opts.to,
 		Timeout:         opts.writeOpts.timeout,
@@ -119,7 +119,7 @@ func RunSteal(opts *StealOptions) (err error) {
 	defer close(done)
 
 	start := time.Now()
-	if err := target.Dump(done, opts.cfgSpec, opts.concurrency); err != nil {
+	if err := target.Dump(done, opts.cfgTables, opts.concurrency); err != nil {
 		return wErrors.Wrap(err, "Error while dumping")
 	}
 

--- a/features/mysql_test.go
+++ b/features/mysql_test.go
@@ -47,7 +47,7 @@ func (s *MysqlTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, new(config.Spec), 4), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, config.Tables{}, 4), "Failed to dump")
 
 	<-done
 

--- a/features/postgres_test.go
+++ b/features/postgres_test.go
@@ -54,7 +54,7 @@ func (s *PostgresTestSuite) TestExample() {
 
 	done := make(chan struct{})
 	defer close(done)
-	s.Require().NoError(dmp.Dump(done, new(config.Spec), 4), "Failed to dump")
+	s.Require().NoError(dmp.Dump(done, config.Tables{}, 4), "Failed to dump")
 
 	<-done
 

--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -35,18 +35,18 @@ func NewAnonymiser(source reader.Reader, tables config.Tables) reader.Reader {
 }
 
 // ReadTable decorates reader.ReadTable method for anonymising rows published from the reader.Reader
-func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt, matchers config.Matchers) error {
+func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
 	logger := log.WithField("table", tableName)
 	logger.Debug("Loading anonymiser config")
 	table := a.tables.FindByName(tableName)
 	if table == nil {
 		logger.Debug("the table is not configured to be anonymised")
-		return a.Reader.ReadTable(tableName, rowChan, opts, matchers)
+		return a.Reader.ReadTable(tableName, rowChan, opts)
 	}
 
 	if len(table.Anonymise) == 0 {
 		logger.Debug("Skipping anonymiser")
-		return a.Reader.ReadTable(tableName, rowChan, opts, matchers)
+		return a.Reader.ReadTable(tableName, rowChan, opts)
 	}
 
 	// Create read/write chanel
@@ -92,7 +92,7 @@ func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 		}
 	}(rowChan, rawChan, table)
 
-	if err := a.Reader.ReadTable(tableName, rawChan, opts, matchers); err != nil {
+	if err := a.Reader.ReadTable(tableName, rawChan, opts); err != nil {
 		return errors.Wrap(err, "anonymiser: error while reading table")
 	}
 

--- a/pkg/anonymiser/anonymiser_test.go
+++ b/pkg/anonymiser/anonymiser_test.go
@@ -17,9 +17,8 @@ func TestReadTable(t *testing.T) {
 
 	tests := []struct {
 		scenario string
-		function func(*testing.T, reader.ReadTableOpt, config.Tables, config.Matchers)
+		function func(*testing.T, reader.ReadTableOpt, config.Tables)
 		opts     reader.ReadTableOpt
-		matchers config.Matchers
 		config   config.Tables
 	}{
 		{
@@ -27,65 +26,61 @@ func TestReadTable(t *testing.T) {
 			function: testWhenAnonymiserIsNotInitialized,
 			opts:     reader.ReadTableOpt{},
 			config:   config.Tables{{Name: "test"}},
-			matchers: make(config.Matchers),
 		},
 		{
 			scenario: "when table is not set in the config",
 			function: testWhenTableIsNotSetInConfig,
 			opts:     reader.ReadTableOpt{},
 			config:   config.Tables{{Name: "test"}},
-			matchers: make(config.Matchers),
 		},
 		{
 			scenario: "when column is anonymised",
 			function: testWhenColumnIsAnonymised,
 			opts:     reader.ReadTableOpt{},
 			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "FirstName"}}},
-			matchers: make(config.Matchers),
 		},
 		{
 			scenario: "when column is anonymised with literal",
 			function: testWhenColumnIsAnonymisedWithLiteral,
 			opts:     reader.ReadTableOpt{},
 			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "literal:Hello"}}},
-			matchers: make(config.Matchers),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			test.function(t, test.opts, test.config, test.matchers)
+			test.function(t, test.opts, test.config)
 		})
 	}
 }
 
-func testWhenAnonymiserIsNotInitialized(t *testing.T, opts reader.ReadTableOpt, tables config.Tables, matchers config.Matchers) {
+func testWhenAnonymiserIsNotInitialized(t *testing.T, opts reader.ReadTableOpt, tables config.Tables) {
 	anonymiser := NewAnonymiser(&mockReader{}, tables)
 
 	rowChan := make(chan database.Row, 1)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts, matchers)
+	err := anonymiser.ReadTable("test", rowChan, opts)
 	require.NoError(t, err)
 }
 
-func testWhenTableIsNotSetInConfig(t *testing.T, opts reader.ReadTableOpt, tables config.Tables, matchers config.Matchers) {
+func testWhenTableIsNotSetInConfig(t *testing.T, opts reader.ReadTableOpt, tables config.Tables) {
 	anonymiser := NewAnonymiser(&mockReader{}, tables)
 
 	rowChan := make(chan database.Row, 1)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("other_table", rowChan, opts, matchers)
+	err := anonymiser.ReadTable("other_table", rowChan, opts)
 	require.NoError(t, err)
 }
 
-func testWhenColumnIsAnonymised(t *testing.T, opts reader.ReadTableOpt, tables config.Tables, matchers config.Matchers) {
+func testWhenColumnIsAnonymised(t *testing.T, opts reader.ReadTableOpt, tables config.Tables) {
 	anonymiser := NewAnonymiser(&mockReader{}, tables)
 
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts, matchers)
+	err := anonymiser.ReadTable("test", rowChan, opts)
 	require.NoError(t, err)
 
 	for {
@@ -95,13 +90,13 @@ func testWhenColumnIsAnonymised(t *testing.T, opts reader.ReadTableOpt, tables c
 	}
 }
 
-func testWhenColumnIsAnonymisedWithLiteral(t *testing.T, opts reader.ReadTableOpt, tables config.Tables, matchers config.Matchers) {
+func testWhenColumnIsAnonymisedWithLiteral(t *testing.T, opts reader.ReadTableOpt, tables config.Tables) {
 	anonymiser := NewAnonymiser(&mockReader{}, tables)
 
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts, matchers)
+	err := anonymiser.ReadTable("test", rowChan, opts)
 	require.NoError(t, err)
 
 	for {
@@ -121,7 +116,7 @@ func (m *mockReader) Close() error                        { return nil }
 func (m *mockReader) FormatColumn(tbl string, col string) string {
 	return fmt.Sprintf("%s.%s", strconv.Quote(tbl), strconv.Quote(col))
 }
-func (m *mockReader) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt, matchers config.Matchers) error {
+func (m *mockReader) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
 	row := make(database.Row)
 	row["column_test"] = "to_be_anonimised"
 	rowChan <- row

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadSpecFromFile(t *testing.T) {
-	_, err := LoadSpecFromFile("")
+func TestLoadFromFile(t *testing.T) {
+	_, err := LoadFromFile("")
 	require.Error(t, err)
 
 	cwd, err := os.Getwd()
@@ -19,7 +20,7 @@ func TestLoadSpecFromFile(t *testing.T) {
 	// klepto/pkg/config/../../fixtures/.klepto.toml
 	configPath := filepath.Join(cwd, "..", "..", "fixtures", ".klepto.toml")
 
-	cfgTables, err := LoadSpecFromFile(configPath)
+	cfgTables, err := LoadFromFile(configPath)
 	require.NoError(t, err)
 	require.Len(t, cfgTables, 3)
 
@@ -31,3 +32,50 @@ func TestLoadSpecFromFile(t *testing.T) {
 	require.NotNil(t, orders)
 	assert.Equal(t, "users.active = TRUE", orders.Filter.Match)
 }
+
+func TestWriteSample(t *testing.T) {
+	w := new(bytes.Buffer)
+
+	err := WriteSample(w)
+	require.NoError(t, err)
+
+	assert.Equal(t, sampleConfig, w.String())
+}
+
+const (
+	sampleConfig = `[Matchers]
+  ActiveUsers = "users.active = TRUE"
+
+[[Tables]]
+  Name = "users"
+  IgnoreData = false
+  [Tables.Filter]
+    Match = "users.active = TRUE"
+    Limit = 100
+    [Tables.Filter.Sorts]
+      "user.id" = "asc"
+  [Tables.Anonymise]
+    email = "EmailAddress"
+    firstName = "FirstName"
+
+[[Tables]]
+  Name = "orders"
+  IgnoreData = false
+  [Tables.Filter]
+    Match = "ActiveUsers"
+    Limit = 10
+
+  [[Tables.Relationships]]
+    Table = ""
+    ForeignKey = "user_id"
+    ReferencedTable = "users"
+    ReferencedKey = "id"
+
+[[Tables]]
+  Name = "logs"
+  IgnoreData = true
+  [Tables.Filter]
+    Match = ""
+    Limit = 0
+`
+)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,10 +19,8 @@ func TestLoadSpecFromFile(t *testing.T) {
 	// klepto/pkg/config/../../fixtures/.klepto.toml
 	configPath := filepath.Join(cwd, "..", "..", "fixtures", ".klepto.toml")
 
-	spec, err := LoadSpecFromFile(configPath)
+	cfgTables, err := LoadSpecFromFile(configPath)
 	require.NoError(t, err)
-
-	cfgTables := spec.Tables
 	require.Len(t, cfgTables, 3)
 
 	users := cfgTables.FindByName("users")
@@ -31,5 +29,5 @@ func TestLoadSpecFromFile(t *testing.T) {
 
 	orders := cfgTables.FindByName("orders")
 	require.NotNil(t, orders)
-	assert.Equal(t, "ActiveUsers", orders.Filter.Match)
+	assert.Equal(t, "users.active = TRUE", orders.Filter.Match)
 }

--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -23,7 +23,7 @@ type (
 	// A Dumper writes a database's structure to the provided stream.
 	Dumper interface {
 		// Dump executes the dump process.
-		Dump(chan<- struct{}, *config.Spec, int) error
+		Dump(chan<- struct{}, config.Tables, int) error
 		// Close closes the dumper resources and releases them.
 		Close() error
 	}

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -28,7 +28,7 @@ type (
 		// FormatColumn returns a escaped table.column string
 		FormatColumn(tableName string, columnName string) string
 		// ReadTable returns a channel with all database rows
-		ReadTable(string, chan<- database.Row, ReadTableOpt, config.Matchers) error
+		ReadTable(string, chan<- database.Row, ReadTableOpt) error
 		// Close closes the reader resources and releases them.
 		Close() error
 	}


### PR DESCRIPTION
The last piece extracted from https://github.com/hellofresh/klepto/pull/110

Instead of passing matcher aliases everywhere and checking them - they are checked and replaced on config load once.

Dependend on https://github.com/hellofresh/klepto/pull/112 and has to be rebased after merge.