### PR TITLE
Support dumping to AWS RDS Postgres servers

### DIFF
--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -29,6 +29,7 @@ type (
 
 		from        string
 		to          string
+		toRDS       bool
 		concurrency int
 		readOpts    connOpts
 		writeOpts   connOpts
@@ -65,6 +66,7 @@ func NewStealCmd() *cobra.Command {
 	persistentFlags.StringVarP(&opts.configPath, "config", "c", config.DefaultConfigFileName, "Path to config file")
 	persistentFlags.StringVarP(&opts.from, "from", "f", "mysql://root:root@tcp(localhost:3306)/klepto", "Database dsn to steal from")
 	persistentFlags.StringVarP(&opts.to, "to", "t", "os://stdout/", "Database to output to (default writes to stdOut)")
+	persistentFlags.BoolVar(&opts.toRDS, "to-rds", false, "If the output server is an AWS RDS server")
 	persistentFlags.IntVar(&opts.concurrency, "concurrency", runtime.NumCPU(), "Sets the amount of dumps to be performed concurrently")
 	persistentFlags.DurationVar(&opts.readOpts.timeout, "read-timeout", 5*time.Minute, "Sets the timeout for read operations")
 	persistentFlags.DurationVar(&opts.readOpts.maxConnLifetime, "read-conn-lifetime", 0, "Sets the maximum amount of time a connection may be reused on the read database")
@@ -99,6 +101,7 @@ func RunSteal(opts *StealOptions) (err error) {
 	source = anonymiser.NewAnonymiser(source, opts.cfgTables)
 	target, err := dumper.NewDumper(dumper.ConnOpts{
 		DSN:             opts.to,
+		IsRDS:           opts.toRDS,
 		Timeout:         opts.writeOpts.timeout,
 		MaxConnLifetime: opts.writeOpts.maxConnLifetime,
 		MaxConns:        opts.writeOpts.maxConns,

--- a/pkg/dumper/dumper.go
+++ b/pkg/dumper/dumper.go
@@ -32,6 +32,8 @@ type (
 	ConnOpts struct {
 		// DSN is the connection address.
 		DSN string
+		// IsRDS identifies if the server is an AWS RDS server
+		IsRDS bool
 		// Timeout is the timeout for dump operations.
 		Timeout time.Duration
 		// MaxConnLifetime is the maximum amount of time a connection may be reused on the read database.

--- a/pkg/dumper/postgres/postgres.go
+++ b/pkg/dumper/postgres/postgres.go
@@ -24,7 +24,7 @@ func (m *driver) NewConnection(opts dumper.ConnOpts, rdr reader.Reader) (dumper.
 	conn.SetMaxIdleConns(opts.MaxIdleConns)
 	conn.SetConnMaxLifetime(opts.MaxConnLifetime)
 
-	return NewDumper(conn, rdr), nil
+	return NewDumper(opts, conn, rdr), nil
 }
 
 func init() {

--- a/pkg/reader/postgres/pg_dump.go
+++ b/pkg/reader/postgres/pg_dump.go
@@ -38,6 +38,7 @@ func (p *PgDump) GetStructure() (string, error) {
 		"--schema-only",
 		"--no-privileges",
 		"--no-owner",
+		"--no-comments",
 	)
 
 	logger.Debug("loading schema for table")


### PR DESCRIPTION
On AWS RDS Postgres servers the "superuser" does not have permission to run the `ALTER TABLE %s DISABLE TRIGGER ALL` command. To get around this I've added a CLI argument `--to-rds` that indicates the dump is being done to an RDS database, and so will switch to looking up all the Foreign Keys in the database, and then using `ALTER TABLE %s DROP CONSTRAINT %s`/`ALTER TABLE %s ADD CONSTRAINT %s %s` to enable and disable the constraints.