### PR TITLE
Fix docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM alpine AS builder
 ARG KLEPTO_VERSION
 
 RUN apk add --no-cache openssl tar \
-    && wget -O klepto.tar.gz https://github.com/hellofresh/klepto/releases/download/${KLEPTO_VERSION}/klepto_linux-amd64.tar.gz \
+    && wget -O klepto.tar.gz https://github.com/hellofresh/klepto/releases/download/v${KLEPTO_VERSION}/klepto_${KLEPTO_VERSION}_linux_amd64.tar.gz \
     && tar -xzf klepto.tar.gz -C /tmp
 
 # ---
 
 FROM scratch
 
-COPY FROM builder /tmp/klepto_linux-amd64 /
+COPY --from=builder /tmp/klepto /
 
-ENTRYPOINT ["/klepto_linux-amd64"]
+ENTRYPOINT ["/klepto"]


### PR DESCRIPTION
Hello 👋!

Just found a problem with Dockerfile.
It was impossible to build an image.

So, glad to propose this fix.

Now command works as expected:
```shell
docker build --build-arg KLEPTO_VERSION=0.3.1 --tag klepto .
```

Thank you 🤝 !