### PR TITLE
Fix Latitude and Longitude anonymization

### DIFF
--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -19,6 +19,8 @@ const (
 	literalPrefix = "literal:"
 	email         = "EmailAddress"
 	username      = "UserName"
+	latitude      = "Latitude"
+	longitude     = "Longitude"
 )
 
 var requireArgs = map[string]bool{
@@ -97,6 +99,8 @@ func (a *anonymiser) ReadTable(tableName string, rowChan chan<- database.Row, op
 						faker.Call([]reflect.Value{})[0].String(),
 						hex.EncodeToString(b),
 					)
+				case latitude, longitude:
+					value = fmt.Sprintf("%f", faker.Call(args)[0].Float())
 				default:
 					value = faker.Call(args)[0].String()
 				}

--- a/pkg/anonymiser/anonymiser_test.go
+++ b/pkg/anonymiser/anonymiser_test.go
@@ -49,6 +49,12 @@ func TestReadTable(t *testing.T) {
 			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "literal:Hello"}}},
 		},
 		{
+			scenario: "when column is anonymised with float value",
+			function: testWhenColumnIsAnonymisedWithFloatValue,
+			opts:     reader.ReadTableOpt{},
+			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "Latitude"}}},
+		},
+		{
 			scenario: "when column anonymiser in invalid",
 			function: testWhenColumnAnonymiserIsInvalid,
 			opts:     reader.ReadTableOpt{},
@@ -138,6 +144,24 @@ func testWhenColumnIsAnonymisedWithLiteral(t *testing.T, opts reader.ReadTableOp
 	select {
 	case row := <-rowChan:
 		assert.Equal(t, "Hello", row["column_test"])
+	case <-timeoutChan:
+		assert.FailNow(t, "Failing due to timeout")
+	}
+}
+
+func testWhenColumnIsAnonymisedWithFloatValue(t *testing.T, opts reader.ReadTableOpt, tables config.Tables) {
+	anonymiser := NewAnonymiser(&mockReader{}, tables)
+
+	rowChan := make(chan database.Row)
+	defer close(rowChan)
+
+	err := anonymiser.ReadTable("test", rowChan, opts)
+	require.NoError(t, err)
+
+	timeoutChan := time.After(waitTimeout)
+	select {
+	case row := <-rowChan:
+		assert.NotEqual(t, "<float32 Value>", row["column_test"])
 	case <-timeoutChan:
 		assert.FailNow(t, "Failing due to timeout")
 	}


### PR DESCRIPTION
The Latitude and Longitude faker functions return a float32 value.

Prior to this fix, the anonymized value was set to the string `"<float32 Value>"` rather than to the string representing the Latiude or Longitude.
