### PR TITLE
Support extracting multiple subsets from one table

### DIFF
--- a/fixtures/.klepto.toml
+++ b/fixtures/.klepto.toml
@@ -4,14 +4,18 @@
 [[Tables]]
   Name = "users"
   IgnoreData = false
-  [Tables.Filter]
-    Match = "users.active = TRUE"
-    Limit = 100
-    [Tables.Filter.Sorts]
-      "user.id" = "asc"
-  [Tables.Anonymise]
-    email = "EmailAddress"
-    firstName = "FirstName"
+
+  [[Tables.Subsets]]
+    Name = "active"
+
+    [Tables.Subsets.Filter]
+      Match = "users.active = TRUE"
+      Limit = 100
+      [Tables.Subsets.Filter.Sorts]
+        "user.id" = "asc"
+    [Tables.Subsets.Anonymise]
+      email = "EmailAddress"
+      firstName = "FirstName"
 
 [[Tables]]
   Name = "orders"
@@ -32,3 +36,34 @@
   [Tables.Filter]
     Match = ""
     Limit = 0
+
+[[Tables]]
+	Name = "vegetables"
+
+[[Tables]]
+  Name = "fruits"
+
+  [Tables.Filter]
+    Match = "fruits.color = 'red'"
+    Limit = 10
+
+  [Tables.Anonymise]
+    name = "FirstName"
+
+[[Tables]]
+  Name = "grains"
+
+  [Tables.Filter]
+    Match = "grains.size = 'large'"
+    Limit = 10
+
+  [Tables.Anonymise]
+    weight = "Digits"
+
+  [[Tables.Subsets]]
+    Name = "starchy"
+
+    [Tables.Subsets.Filter]
+      Match = "grains.starchy = TRUE"
+    [Tables.Subsets.Anonymise]
+      name = "FirstName"

--- a/pkg/anonymiser/anonymiser_test.go
+++ b/pkg/anonymiser/anonymiser_test.go
@@ -15,7 +15,7 @@ import (
 
 const waitTimeout = time.Second
 
-func TestReadTable(t *testing.T) {
+func TestReadSubset(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -28,55 +28,135 @@ func TestReadTable(t *testing.T) {
 			scenario: "when anonymiser is not initialized",
 			function: testWhenAnonymiserIsNotInitialized,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test"}},
+			config: config.Tables{
+				{
+					Name:    "test",
+					Subsets: []*config.Subset{{Name: "_deafult"}},
+				},
+			},
 		},
 		{
 			scenario: "when table is not set in the config",
 			function: testWhenTableIsNotSetInConfig,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test"}},
+			config: config.Tables{
+				{
+					Name:    "test",
+					Subsets: []*config.Subset{{Name: "_deafult"}},
+				},
+			},
 		},
 		{
 			scenario: "when column is anonymised",
 			function: testWhenColumnIsAnonymised,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "FirstName"}}},
+			config: config.Tables{
+				{
+					Name: "test",
+					Subsets: []*config.Subset{
+						{
+							Name:      "_deafult",
+							Anonymise: map[string]string{"column_test": "FirstName"},
+						},
+					},
+				},
+			},
 		},
 		{
 			scenario: "when column is anonymised with literal",
 			function: testWhenColumnIsAnonymisedWithLiteral,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "literal:Hello"}}},
+			config: config.Tables{
+				{
+					Name: "test",
+					Subsets: []*config.Subset{
+						{
+							Name:      "_deafult",
+							Anonymise: map[string]string{"column_test": "literal:Hello"},
+						},
+					},
+				},
+			},
 		},
 		{
 			scenario: "when column anonymiser in invalid",
 			function: testWhenColumnAnonymiserIsInvalid,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "Hello"}}},
+			config: config.Tables{
+				{
+					Name: "test",
+					Subsets: []*config.Subset{
+						{
+							Name:      "_deafult",
+							Anonymise: map[string]string{"column_test": "Hello"},
+						},
+					},
+				},
+			},
 		},
 		{
 			scenario: "when column anonymiser require args",
 			function: testWhenColumnAnonymiserRequireArgs,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "DigitsN:20"}}},
+			config: config.Tables{
+				{
+					Name: "test",
+					Subsets: []*config.Subset{
+						{
+							Name:      "_deafult",
+							Anonymise: map[string]string{"column_test": "DigitsN:20"},
+						},
+					},
+				},
+			},
 		},
 		{
 			scenario: "when column anonymiser require multiple args",
 			function: testWhenColumnAnonymiserRequireMultipleArgs,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "Year:2020:2021"}}},
+			config: config.Tables{
+				{
+					Name: "test",
+					Subsets: []*config.Subset{
+						{
+							Name:      "_deafult",
+							Anonymise: map[string]string{"column_test": "Year:2020:2021"},
+						},
+					},
+				},
+			},
 		},
 		{
 			scenario: "when column anonymiser require args but no values are passed",
 			function: testWhenColumnAnonymiserRequireArgsNoValues,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test": "CreditCardNum"}}},
+			config: config.Tables{
+				{
+					Name: "test",
+					Subsets: []*config.Subset{
+						{
+							Name:      "_deafult",
+							Anonymise: map[string]string{"column_test": "CreditCardNum"},
+						},
+					},
+				},
+			},
 		},
 		{
 			scenario: "when column anonymiser require args but the value passed is invalid",
 			function: testWhenColumnAnonymiserRequireArgsInvalidValues,
 			opts:     reader.ReadTableOpt{},
-			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test1": "CharactersN:invalid", "column_test2": "Password:1:2:yes"}}},
+			config: config.Tables{
+				{
+					Name: "test",
+					Subsets: []*config.Subset{
+						{
+							Name:      "_deafult",
+							Anonymise: map[string]string{"column_test1": "CharactersN:invalid", "column_test2": "Password:1:2:yes"},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -93,7 +173,7 @@ func testWhenAnonymiserIsNotInitialized(t *testing.T, opts reader.ReadTableOpt, 
 	rowChan := make(chan database.Row, 1)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 }
 
@@ -103,7 +183,7 @@ func testWhenTableIsNotSetInConfig(t *testing.T, opts reader.ReadTableOpt, table
 	rowChan := make(chan database.Row, 1)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("other_table", rowChan, opts)
+	err := anonymiser.ReadSubset("other_table", 0, rowChan, opts)
 	require.NoError(t, err)
 }
 
@@ -113,7 +193,7 @@ func testWhenColumnIsAnonymised(t *testing.T, opts reader.ReadTableOpt, tables c
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -131,7 +211,7 @@ func testWhenColumnIsAnonymisedWithLiteral(t *testing.T, opts reader.ReadTableOp
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -149,7 +229,7 @@ func testWhenColumnAnonymiserIsInvalid(t *testing.T, opts reader.ReadTableOpt, t
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -167,7 +247,7 @@ func testWhenColumnAnonymiserRequireArgs(t *testing.T, opts reader.ReadTableOpt,
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -186,7 +266,7 @@ func testWhenColumnAnonymiserRequireMultipleArgs(t *testing.T, opts reader.ReadT
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -204,7 +284,7 @@ func testWhenColumnAnonymiserRequireArgsNoValues(t *testing.T, opts reader.ReadT
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -222,7 +302,7 @@ func testWhenColumnAnonymiserRequireArgsInvalidValues(t *testing.T, opts reader.
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable("test", rowChan, opts)
+	err := anonymiser.ReadSubset("test", 0, rowChan, opts)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -245,7 +325,7 @@ func (m *mockReader) Close() error                        { return nil }
 func (m *mockReader) FormatColumn(tbl string, col string) string {
 	return fmt.Sprintf("%s.%s", strconv.Quote(tbl), strconv.Quote(col))
 }
-func (m *mockReader) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+func (m *mockReader) ReadSubset(tableName string, subsetIndex int, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
 	row := make(database.Row)
 	row["column_test"] = "to_be_anonimised"
 	rowChan <- row

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,15 +22,53 @@ func TestLoadFromFile(t *testing.T) {
 
 	cfgTables, err := LoadFromFile(configPath)
 	require.NoError(t, err)
-	require.Len(t, cfgTables, 3)
-
-	users := cfgTables.FindByName("users")
-	require.NotNil(t, users)
-	assert.Equal(t, "users.active = TRUE", users.Filter.Match)
+	require.Len(t, cfgTables, 6)
 
 	orders := cfgTables.FindByName("orders")
 	require.NotNil(t, orders)
-	assert.Equal(t, "users.active = TRUE", orders.Filter.Match)
+	assert.Equal(t, "_default", orders.Subsets[0].Name)
+	assert.Equal(t, "users.active = TRUE", orders.Subsets[0].Filter.Match)
+
+	// When no Subsets, Filters, or Anonymise blocks are defined we expect to
+	// create a single Subset for the table root with no Filter or Anonymise.
+	veggies := cfgTables.FindByName("vegetables")
+	require.Equal(t, 1, len(veggies.Subsets))
+	require.Equal(t, "_default", veggies.Subsets[0].Name)
+	require.Equal(t, "", veggies.Subsets[0].Filter.Match)
+	require.Equal(t, 0, len(orders.Subsets[0].Anonymise))
+
+	// When no Subsets are defined, but Filters and Anonymise are present at the
+	// table root, we expect to create a single Subset for the table root with
+	// the Filter and Anonymise information copied over.
+	fruits := cfgTables.FindByName("fruits")
+	require.Equal(t, 1, len(fruits.Subsets))
+	require.Equal(t, "_default", fruits.Subsets[0].Name)
+	require.Equal(t, "fruits.color = 'red'", fruits.Subsets[0].Filter.Match)
+	require.Equal(t, 1, len(fruits.Subsets[0].Anonymise))
+	require.Equal(t, "FirstName", fruits.Subsets[0].Anonymise["name"])
+
+	// When Subsets are explicitly defined and no Filters or Anonymise are defined
+	// at the table root, we expect only the explicit Subsets to exist in the config.
+	users := cfgTables.FindByName("users")
+	require.NotNil(t, users)
+	assert.Equal(t, "active", users.Subsets[0].Name)
+	assert.Equal(t, "users.active = TRUE", users.Subsets[0].Filter.Match)
+	require.Equal(t, 1, len(users.Subsets))
+
+	// When Subsets are explicitly defined and Filters or Anonymise are also
+	// defined at the table root, the root-level filters and anonymise are moved
+	// to a new _default Subset.
+	grains := cfgTables.FindByName("grains")
+	require.Equal(t, 2, len(grains.Subsets))
+
+	require.Equal(t, "starchy", grains.Subsets[0].Name)
+	require.Equal(t, "grains.starchy = TRUE", grains.Subsets[0].Filter.Match)
+	require.Equal(t, "FirstName", grains.Subsets[0].Anonymise["name"])
+
+	require.Equal(t, "_default", grains.Subsets[1].Name)
+	require.Equal(t, "grains.size = 'large'", grains.Subsets[1].Filter.Match)
+	require.Equal(t, 1, len(grains.Subsets[1].Anonymise))
+	require.Equal(t, "Digits", grains.Subsets[1].Anonymise["weight"])
 }
 
 func TestWriteSample(t *testing.T) {

--- a/pkg/dumper/query/dumper.go
+++ b/pkg/dumper/query/dumper.go
@@ -91,8 +91,10 @@ func (d *textDumper) Dump(done chan<- struct{}, cfgTables config.Tables, concurr
 			}
 		}(tbl)
 
-		if err := d.reader.ReadTable(tbl, rowChan, opts); err != nil {
-			log.WithError(err).WithField("table", tbl).Error("error while reading table")
+		for subsetIndex, subset := range opts.Subsets {
+			if err := d.reader.ReadSubset(tbl, subsetIndex, rowChan, opts); err != nil {
+				log.WithError(err).Error(fmt.Sprintf("Failed to read '%s' subset of table '%s'", subset.Name, tbl))
+			}
 		}
 	}
 

--- a/pkg/reader/reader_test.go
+++ b/pkg/reader/reader_test.go
@@ -11,37 +11,42 @@ import (
 
 func TestNewReadTableOpt(t *testing.T) {
 	tableCfg := &config.Table{
-		Filter: config.Filter{
-			Match: "foo-match",
-			Limit: 123,
-			Sorts: map[string]string{"foo": "asc", "bar": "desc"},
-		},
-		Relationships: []*config.Relationship{
+		Subsets: []*config.Subset{
 			{
-				Table:           "r1-table",
-				ForeignKey:      "r1-fk",
-				ReferencedTable: "r1-reference-table",
-				ReferencedKey:   "r1-reference-key",
-			}, {
-				Table:           "r2-table",
-				ForeignKey:      "r2-fk",
-				ReferencedTable: "r2-reference-table",
-				ReferencedKey:   "r2-reference-key",
+				Name: "_default",
+				Filter: config.Filter{
+					Match: "foo-match",
+					Limit: 123,
+					Sorts: map[string]string{"foo": "asc", "bar": "desc"},
+				},
+				Relationships: []*config.Relationship{
+					{
+						Table:           "r1-table",
+						ForeignKey:      "r1-fk",
+						ReferencedTable: "r1-reference-table",
+						ReferencedKey:   "r1-reference-key",
+					}, {
+						Table:           "r2-table",
+						ForeignKey:      "r2-fk",
+						ReferencedTable: "r2-reference-table",
+						ReferencedKey:   "r2-reference-key",
+					},
+				},
 			},
 		},
 	}
 
 	tableOpt := NewReadTableOpt(tableCfg)
 
-	assert.Equal(t, tableCfg.Filter.Match, tableOpt.Match)
-	assert.Equal(t, tableCfg.Filter.Limit, tableOpt.Limit)
-	assert.Equal(t, tableCfg.Filter.Sorts, tableOpt.Sorts)
+	assert.Equal(t, tableCfg.Subsets[0].Filter.Match, tableOpt.Subsets[0].Match)
+	assert.Equal(t, tableCfg.Subsets[0].Filter.Limit, tableOpt.Subsets[0].Limit)
+	assert.Equal(t, tableCfg.Subsets[0].Filter.Sorts, tableOpt.Subsets[0].Sorts)
 
-	require.Equal(t, len(tableCfg.Relationships), len(tableOpt.Relationships))
-	for i := range tableCfg.Relationships {
-		assert.Equal(t, tableCfg.Relationships[i].Table, tableOpt.Relationships[i].Table)
-		assert.Equal(t, tableCfg.Relationships[i].ForeignKey, tableOpt.Relationships[i].ForeignKey)
-		assert.Equal(t, tableCfg.Relationships[i].ReferencedTable, tableOpt.Relationships[i].ReferencedTable)
-		assert.Equal(t, tableCfg.Relationships[i].ReferencedKey, tableOpt.Relationships[i].ReferencedKey)
+	require.Equal(t, len(tableCfg.Subsets[0].Relationships), len(tableOpt.Subsets[0].Relationships))
+	for i := range tableCfg.Subsets[0].Relationships {
+		assert.Equal(t, tableCfg.Subsets[0].Relationships[i].Table, tableOpt.Subsets[0].Relationships[i].Table)
+		assert.Equal(t, tableCfg.Subsets[0].Relationships[i].ForeignKey, tableOpt.Subsets[0].Relationships[i].ForeignKey)
+		assert.Equal(t, tableCfg.Subsets[0].Relationships[i].ReferencedTable, tableOpt.Subsets[0].Relationships[i].ReferencedTable)
+		assert.Equal(t, tableCfg.Subsets[0].Relationships[i].ReferencedKey, tableOpt.Subsets[0].Relationships[i].ReferencedKey)
 	}
 }


### PR DESCRIPTION
This is a more in-depth approach to #139 than the `--data-only` flag I proposed in #140. That flag may still be helpful in other cases, so I'd consider that PR separately.

---

This introduces the concept of table Subsets, which allow multiple Filter, Anonymise, and Relationships configurations to be attached to a single table. All functionality related to reading table data is refactored from operating on an entire table to operating on a single subset (ReadTable becomes ReadSubset).

For compatibility, Filter, Anonymise, and Relationships blocks defined at the root Table level are copied into a `_deafult` Subset when the config file is parsed.

So, a config like this:

```toml
[[Tables]]
  Name = "grains"

  [Tables.Filter]
    Match = "grains.size = 'large'"
    Limit = 10

  [Tables.Anonymise]
    weight = "Digits"
```

Will be parsed into something like this behind the scenes:

```
{
  Name: "grains",
  Subsets: [
    {
      Name: "_default",
      Filter: {
        Match: "grains.size = 'large'",
        Limit: 10
      },
      Anonymise: {
        weight: "Digits"
      }
    },
  ]
}
```

One area that I'm somewhat questioningis how things should be handled when Filter config exists both at the root level and in Subsets

For example:

```toml
[[Tables]]
  Name = "grains"

  [Tables.Filter]
    Match = "grains.size = 'large'"
    Limit = 10

  [Tables.Anonymise]
    weight = "Digits"

  [[Tables.Subsets]]
    Name = "starchy"

    [Tables.Subsets.Filter]
      Match = "grains.starchy = TRUE"
    [Tables.Subsets.Anonymise]
      name = "FirstName"
```

This config will currently be parsed into a tree that looks like this:

```
{
  Name: "grains",
  Subsets: [
    {
      Name: "_default",
      Filter: {
        Match: "grains.size = 'large'",
        Limit: 10
      },
      Anonymise: {
        weight: "Digits"
      }
    },
    {
      Name: "starchy",
      Filter: {
        Match: "grains.starchy = TRUE"
      },
      Anonymise: {
        name: "FirstName"
      }
    }
  ]
}
```

I think this is a reasonable approach overall — it treats the root level as its own separate subset — but I can also see how it could be confusing if people thought that the Filter, Anonymise, and Relationships blocks defined at the root level would be inherited by all subsets.

The alternative is to make this scenario throw an error, so a table can either use a root-level configuration, or it can define Subsets, but it cannot do both.

Thoughts?
