### PR TITLE
Build darwin-arm64 for Apple Silicon

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,13 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
+
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: linux
+        goarch: arm64
 
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Adds a darwin-arm64 build configuration for Apple M1/M2 to the goreleaser config.
