### PR TITLE
Fix imports and cleanup code

### DIFF
--- a/features/mysql_test.go
+++ b/features/mysql_test.go
@@ -3,19 +3,19 @@ package features
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	_ "github.com/hellofresh/klepto/pkg/dumper/mysql"
 	"github.com/hellofresh/klepto/pkg/reader"
 	_ "github.com/hellofresh/klepto/pkg/reader/mysql"
-	"github.com/stretchr/testify/suite"
 )
 
 type MysqlTestSuite struct {
@@ -105,7 +105,7 @@ func (s *MysqlTestSuite) dropDatabase(name string) {
 }
 
 func (s *MysqlTestSuite) loadFixture(dsn string, file string) {
-	data, err := ioutil.ReadFile(path.Join("../fixtures/", file))
+	data, err := os.ReadFile(path.Join("../fixtures/", file))
 	s.Require().NoError(err, "Unable to load fixture file")
 
 	conn, err := sql.Open("mysql", dsn)

--- a/features/postgres_test.go
+++ b/features/postgres_test.go
@@ -3,7 +3,6 @@ package features
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -11,12 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	_ "github.com/hellofresh/klepto/pkg/dumper/postgres"
 	"github.com/hellofresh/klepto/pkg/reader"
 	_ "github.com/hellofresh/klepto/pkg/reader/postgres"
-	"github.com/stretchr/testify/suite"
 )
 
 type PostgresTestSuite struct {
@@ -103,12 +103,12 @@ func (s *PostgresTestSuite) dropDatabase(name string) {
 }
 
 func (s *PostgresTestSuite) loadFixture(dsn string, file string) {
-	data, err := ioutil.ReadFile(path.Join("../fixtures/", file))
+	data, err := os.ReadFile(path.Join("../fixtures/", file))
 	s.Require().NoError(err, "Unable to load fixture file")
 
 	conn, err := sql.Open("postgres", dsn)
-	defer conn.Close()
 	s.Require().NoError(err, "Unable to open db connection to load fixture")
+	defer conn.Close()
 
 	_, err = conn.Exec(string(data))
 	s.Require().NoError(err, "Unable to execute fixture")

--- a/fixtures/.klepto.toml
+++ b/fixtures/.klepto.toml
@@ -8,7 +8,7 @@
     Match = "users.active = TRUE"
     Limit = 100
     [Tables.Filter.Sorts]
-      "user.id" = "asc"
+      "users.id" = "asc"
   [Tables.Anonymise]
     email = "EmailAddress"
     firstName = "FirstName"

--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -8,10 +8,11 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/database"
 	"github.com/hellofresh/klepto/pkg/reader"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/anonymiser/anonymiser_test.go
+++ b/pkg/anonymiser/anonymiser_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/database"
 	"github.com/hellofresh/klepto/pkg/reader"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const waitTimeout = time.Second

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,7 +131,7 @@ func WriteSample(w io.Writer) error {
 				Name: "users",
 				Filter: Filter{
 					Match: "users.active = TRUE",
-					Sorts: map[string]string{"user.id": "asc"},
+					Sorts: map[string]string{"users.id": "asc"},
 					Limit: 100,
 				},
 				Anonymise: map[string]string{"firstName": "FirstName", "email": "EmailAddress"},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,7 +53,7 @@ const (
     Match = "users.active = TRUE"
     Limit = 100
     [Tables.Filter.Sorts]
-      "user.id" = "asc"
+      "users.id" = "asc"
   [Tables.Anonymise]
     email = "EmailAddress"
     firstName = "FirstName"

--- a/pkg/dsn/dsn.go
+++ b/pkg/dsn/dsn.go
@@ -11,9 +11,9 @@ import (
 
 var (
 	// ErrEmptyDsn defines error returned when no dsn is provided
-	ErrEmptyDsn = errors.New("Empty string provided for dsn")
+	ErrEmptyDsn = errors.New("empty string provided for dsn")
 	// ErrInvalidDsn defines error returned when the dsn is invalid
-	ErrInvalidDsn = errors.New("Invalid dsn")
+	ErrInvalidDsn = errors.New("invalid dsn")
 
 	// From https://github.com/go-sql-driver/mysql/blob/f4bf8e8e0aa93d4ead0c6473503ca2f5d5eb65a8/utils.go#L34
 	regex = regexp.MustCompile(

--- a/pkg/dumper/mysql/dumper.go
+++ b/pkg/dumper/mysql/dumper.go
@@ -10,11 +10,12 @@ import (
 	"sync/atomic"
 
 	"github.com/go-sql-driver/mysql"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hellofresh/klepto/pkg/database"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	"github.com/hellofresh/klepto/pkg/dumper/engine"
 	"github.com/hellofresh/klepto/pkg/reader"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/dumper/mysql/mysql.go
+++ b/pkg/dumper/mysql/mysql.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 
 	"github.com/go-sql-driver/mysql"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hellofresh/klepto/pkg/dumper"
 	"github.com/hellofresh/klepto/pkg/reader"
-	log "github.com/sirupsen/logrus"
 )
 
 type driver struct{}

--- a/pkg/dumper/postgres/dumper.go
+++ b/pkg/dumper/postgres/dumper.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/hellofresh/klepto/pkg/config"
+	"github.com/lib/pq"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hellofresh/klepto/pkg/database"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	"github.com/hellofresh/klepto/pkg/dumper/engine"
 	"github.com/hellofresh/klepto/pkg/reader"
-	"github.com/lib/pq"
-	log "github.com/sirupsen/logrus"
 )
 
 type (
@@ -188,9 +188,8 @@ func (d *pgDumper) insertIntoTable(txn *sql.Tx, tableName string, rowChan <-chan
 		rowValues := make([]interface{}, len(columns))
 		for i, col := range columns {
 			val := row[col]
-			switch val.(type) {
-			case []byte:
-				val = string(val.([]byte))
+			if bytesVal, ok := val.([]byte); ok {
+				val = string(bytesVal)
 			}
 
 			rowValues[i] = val
@@ -211,18 +210,4 @@ func (d *pgDumper) insertIntoTable(txn *sql.Tx, tableName string, rowChan <-chan
 	}
 
 	return inserted, nil
-}
-
-func (d *pgDumper) relationshipConfigToOptions(relationshipsConfig []*config.Relationship) []*reader.RelationshipOpt {
-	var opts []*reader.RelationshipOpt
-
-	for _, r := range relationshipsConfig {
-		opts = append(opts, &reader.RelationshipOpt{
-			ReferencedTable: r.ReferencedTable,
-			ReferencedKey:   r.ReferencedKey,
-			ForeignKey:      r.ForeignKey,
-		})
-	}
-
-	return opts
 }

--- a/pkg/dumper/query/dumper.go
+++ b/pkg/dumper/query/dumper.go
@@ -136,42 +136,28 @@ func (d *textDumper) toSQLColumnMap(row database.Row) (map[string]interface{}, e
 
 // ResolveType accepts a value and attempts to determine its type
 func (d *textDumper) toSQLStringValue(src interface{}) (string, error) {
-	switch src.(type) {
+	switch value := src.(type) {
 	case int64:
-		if value, ok := src.(int64); ok {
-			return strconv.FormatInt(value, 10), nil
-		}
+		return strconv.FormatInt(value, 10), nil
 	case float64:
-		if value, ok := src.(float64); ok {
-			return fmt.Sprintf("%v", value), nil
-		}
+		return fmt.Sprintf("%v", value), nil
 	case bool:
-		if value, ok := src.(bool); ok {
-			return strconv.FormatBool(value), nil
-		}
+		return strconv.FormatBool(value), nil
 	case string:
-		if value, ok := src.(string); ok {
-			return value, nil
-		}
+		return value, nil
 	case []byte:
 		// TODO handle blobs?
-		if value, ok := src.([]byte); ok {
-			return string(value), nil
-		}
+		return string(value), nil
 	case time.Time:
-		if value, ok := src.(time.Time); ok {
-			return value.String(), nil
-		}
+		return value.String(), nil
 	case nil:
 		return "NULL", nil
 	case *interface{}:
-		if src == nil {
+		if value == nil {
 			return "NULL", nil
 		}
-		return d.toSQLStringValue(*(src.(*interface{})))
+		return d.toSQLStringValue(*value)
 	default:
 		return "", errors.New("could not parse type")
 	}
-
-	return "", nil
 }

--- a/pkg/dumper/query/writer.go
+++ b/pkg/dumper/query/writer.go
@@ -28,6 +28,6 @@ func getOutputWriter(dsn string) (io.Writer, error) {
 	case "os":
 		return getOsWriter(config.Address), nil
 	default:
-		return nil, fmt.Errorf("Unknown output writer type: %v", config.Type)
+		return nil, fmt.Errorf("unknown output writer type: %v", config.Type)
 	}
 }

--- a/pkg/reader/mysql/mysql.go
+++ b/pkg/reader/mysql/mysql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 
 	"github.com/go-sql-driver/mysql"
+
 	"github.com/hellofresh/klepto/pkg/reader"
 )
 

--- a/pkg/reader/mysql/reader.go
+++ b/pkg/reader/mysql/reader.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hellofresh/klepto/pkg/reader"
 	"github.com/hellofresh/klepto/pkg/reader/engine"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/reader/postgres/reader.go
+++ b/pkg/reader/postgres/reader.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hellofresh/klepto/pkg/reader"
 	"github.com/hellofresh/klepto/pkg/reader/engine"
-	log "github.com/sirupsen/logrus"
 )
 
 type (


### PR DESCRIPTION
This PR fix a typo in the sample config, removes some unused code, replace deprecated `ioutil` calls and other static checks