### PR TITLE
Allow multiple steal from same table

### DIFF
--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -100,7 +100,7 @@ func RunSteal(opts *StealOptions) (err error) {
 		}
 	}()
 
-	source = anonymiser.NewAnonymiser(source, opts.cfgTables)
+	source = anonymiser.NewAnonymiser(source)
 	target, err := dumper.NewDumper(dumper.ConnOpts{
 		DSN:             opts.to,
 		IsRDS:           opts.toRDS,

--- a/fixtures/.klepto_subsets.toml
+++ b/fixtures/.klepto_subsets.toml
@@ -1,0 +1,21 @@
+[Matchers]
+  AdminUsers = "users.administrator = TRUE"
+  NonAdminUsers = "users.administrator = FALSE"
+
+[[Tables]]
+  Name = "users"
+  IgnoreData = false
+
+  [Tables.Filter]
+    Match = "AdminUsers"
+
+[[Tables]]
+  Name = "users"
+  IgnoreData = false
+
+  [Tables.Filter]
+    Match = "NonAdminUsers"
+
+  [Tables.Anonymise]
+    email = "EmailAddress"
+    first_name = "FirstName"

--- a/fixtures/mysql_subsets.sql
+++ b/fixtures/mysql_subsets.sql
@@ -1,0 +1,13 @@
+CREATE TABLE users
+(
+  id varchar(36) PRIMARY KEY NOT NULL,
+  first_name varchar(50) NOT NULL,
+  email varchar(255) NOT NULL,
+  administrator tinyint(1) NOT NULL
+);
+
+INSERT INTO `users` VALUES ('a1fbd1e4-6660-11ed-a7a1-af628227c989', 'Jimmy', 'jimmy@hellofresh.com', true);
+INSERT INTO `users` VALUES ('9e1f48ee-6660-11ed-a476-13572d3d8c7d', 'Kairos', 'kairos@hellofresh.com', true);
+INSERT INTO `users` VALUES ('9ac03f0a-6660-11ed-85cc-0f46f8189a84', 'Nutmeg', 'nutmeg@hellofresh.com', true);
+INSERT INTO `users` VALUES ('95949b2a-6660-11ed-b8e6-ab0136b45676', 'Puppy', 'puppy@hellofresh.com', false);
+INSERT INTO `users` VALUES ('90c91eea-6660-11ed-a24d-b3bc8fe05281', 'Patito', 'patito@hellofresh.com', false);

--- a/fixtures/pg_subsets.sql
+++ b/fixtures/pg_subsets.sql
@@ -1,0 +1,20 @@
+--
+-- PostgreSQL database dump
+--
+
+CREATE TABLE "users" (
+  id UUID PRIMARY KEY NOT NULL,
+  first_name character varying(50) NOT NULL,
+  email character varying(255) NOT NULL,
+  administrator boolean NOT NULL
+);
+
+INSERT INTO "users" VALUES ('a1fbd1e4-6660-11ed-a7a1-af628227c989', 'Jimmy', 'jimmy@hellofresh.com', true);
+INSERT INTO "users" VALUES ('9e1f48ee-6660-11ed-a476-13572d3d8c7d', 'Kairos', 'kairos@hellofresh.com', true);
+INSERT INTO "users" VALUES ('9ac03f0a-6660-11ed-85cc-0f46f8189a84', 'Nutmeg', 'nutmeg@hellofresh.com', true);
+INSERT INTO "users" VALUES ('95949b2a-6660-11ed-b8e6-ab0136b45676', 'Puppy', 'puppy@hellofresh.com', false);
+INSERT INTO "users" VALUES ('90c91eea-6660-11ed-a24d-b3bc8fe05281', 'Patito', 'patito@hellofresh.com', false);
+
+--
+-- PostgreSQL database dump complete
+--

--- a/pkg/anonymiser/anonymiser.go
+++ b/pkg/anonymiser/anonymiser.go
@@ -47,13 +47,13 @@ func NewAnonymiser(source reader.Reader) reader.Reader {
 }
 
 // ReadTable decorates reader.ReadTable method for anonymising rows published from the reader.Reader
-func (a *anonymiser) ReadTable(table config.Table, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+func (a *anonymiser) ReadTable(table config.Table, rowChan chan<- database.Row) error {
 	logger := log.WithField("table", table.Name)
 	logger.Debug("Loading anonymiser config")
 
 	if len(table.Anonymise) == 0 {
 		logger.Debug("Skipping anonymiser")
-		return a.Reader.ReadTable(table, rowChan, opts)
+		return a.Reader.ReadTable(table, rowChan)
 	}
 
 	// Create read/write chanel
@@ -106,7 +106,7 @@ func (a *anonymiser) ReadTable(table config.Table, rowChan chan<- database.Row, 
 		}
 	}(rowChan, rawChan, &table)
 
-	if err := a.Reader.ReadTable(table, rawChan, opts); err != nil {
+	if err := a.Reader.ReadTable(table, rawChan); err != nil {
 		return fmt.Errorf("anonymiser: error while reading table: %w", err)
 	}
 

--- a/pkg/anonymiser/anonymiser_test.go
+++ b/pkg/anonymiser/anonymiser_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/database"
-	"github.com/hellofresh/klepto/pkg/reader"
 )
 
 const waitTimeout = time.Second
@@ -89,7 +88,7 @@ func testWhenAnonymiserIsNotInitialized(t *testing.T, table config.Table) {
 	rowChan := make(chan database.Row, 1)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(config.Table{Name: "test"}, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(config.Table{Name: "test"}, rowChan)
 	require.NoError(t, err)
 }
 
@@ -99,7 +98,7 @@ func testWhenTableIsNotSetInConfig(t *testing.T, table config.Table) {
 	rowChan := make(chan database.Row, 1)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(config.Table{Name: "other_table"}, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(config.Table{Name: "other_table"}, rowChan)
 	require.NoError(t, err)
 }
 
@@ -109,7 +108,7 @@ func testWhenColumnIsAnonymised(t *testing.T, table config.Table) {
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -127,7 +126,7 @@ func testWhenColumnIsAnonymisedWithLiteral(t *testing.T, table config.Table) {
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -145,7 +144,7 @@ func testWhenColumnIsAnonymisedWithFloatValue(t *testing.T, table config.Table) 
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -163,7 +162,7 @@ func testWhenColumnAnonymiserIsInvalid(t *testing.T, table config.Table) {
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -181,7 +180,7 @@ func testWhenColumnAnonymiserRequireArgs(t *testing.T, table config.Table) {
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -200,7 +199,7 @@ func testWhenColumnAnonymiserRequireMultipleArgs(t *testing.T, table config.Tabl
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -218,7 +217,7 @@ func testWhenColumnAnonymiserRequireArgsNoValues(t *testing.T, table config.Tabl
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -236,7 +235,7 @@ func testWhenColumnAnonymiserRequireArgsInvalidValues(t *testing.T, table config
 	rowChan := make(chan database.Row)
 	defer close(rowChan)
 
-	err := anonymiser.ReadTable(table, rowChan, reader.ReadTableOpt{})
+	err := anonymiser.ReadTable(table, rowChan)
 	require.NoError(t, err)
 
 	timeoutChan := time.After(waitTimeout)
@@ -259,7 +258,7 @@ func (m *mockReader) Close() error                        { return nil }
 func (m *mockReader) FormatColumn(tbl string, col string) string {
 	return fmt.Sprintf("%s.%s", strconv.Quote(tbl), strconv.Quote(col))
 }
-func (m *mockReader) ReadTable(table config.Table, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+func (m *mockReader) ReadTable(table config.Table, rowChan chan<- database.Row) error {
 	row := make(database.Row)
 	row["column_test"] = "to_be_anonimised"
 	rowChan <- row

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,18 @@ func (t Tables) FindByName(name string) *Table {
 	return nil
 }
 
+// FilterByName find all tables that match given name.
+func (t Tables) FilterByName(name string) Tables {
+	tables := make(Tables, 0, len(t))
+	for _, table := range t {
+		if table.Name == name {
+			tables = append(tables, table)
+		}
+	}
+
+	return tables
+}
+
 // LoadFromFile loads klepto tables config from file
 func LoadFromFile(configPath string) (Tables, error) {
 	if configPath == "" {

--- a/pkg/dumper/engine/engine.go
+++ b/pkg/dumper/engine/engine.go
@@ -95,13 +95,10 @@ func (e *Engine) readAndDumpTables(done chan<- struct{}, cfgTables config.Tables
 			tableConfigs = append(tableConfigs, &config.Table{Name: tbl})
 		}
 		for _, tableConfig := range tableConfigs {
-			var opts reader.ReadTableOpt
 			if tableConfig.IgnoreData {
 				logger.Debug("ignoring data to dump")
 				continue
 			}
-
-			opts = reader.NewReadTableOpt(tableConfig)
 
 			// Create read/write chanel
 			rowChan := make(chan database.Row)
@@ -117,11 +114,11 @@ func (e *Engine) readAndDumpTables(done chan<- struct{}, cfgTables config.Tables
 				}
 			}(tbl, rowChan, logger)
 
-			go func(table config.Table, opts reader.ReadTableOpt, rowChan chan<- database.Row, logger *log.Entry) {
-				if err := e.reader.ReadTable(table, rowChan, opts); err != nil {
+			go func(table config.Table, rowChan chan<- database.Row, logger *log.Entry) {
+				if err := e.reader.ReadTable(table, rowChan); err != nil {
 					logger.WithError(err).Error("Failed to read table")
 				}
-			}(*tableConfig, opts, rowChan, logger)
+			}(*tableConfig, rowChan, logger)
 		}
 	}
 

--- a/pkg/dumper/engine/engine.go
+++ b/pkg/dumper/engine/engine.go
@@ -118,7 +118,7 @@ func (e *Engine) readAndDumpTables(done chan<- struct{}, cfgTables config.Tables
 			}(tbl, rowChan, logger)
 
 			go func(table config.Table, opts reader.ReadTableOpt, rowChan chan<- database.Row, logger *log.Entry) {
-				if err := e.reader.ReadTable(table.Name, rowChan, opts); err != nil {
+				if err := e.reader.ReadTable(table, rowChan, opts); err != nil {
 					logger.WithError(err).Error("Failed to read table")
 				}
 			}(*tableConfig, opts, rowChan, logger)

--- a/pkg/dumper/query/dumper.go
+++ b/pkg/dumper/query/dumper.go
@@ -93,7 +93,7 @@ func (d *textDumper) Dump(done chan<- struct{}, cfgTables config.Tables, concurr
 				}
 			}(tbl)
 
-			if err := d.reader.ReadTable(tableConfig.Name, rowChan, reader.NewReadTableOpt(tableConfig)); err != nil {
+			if err := d.reader.ReadTable(*tableConfig, rowChan, reader.NewReadTableOpt(tableConfig)); err != nil {
 				log.WithError(err).WithField("table", tbl).Error("error while reading table")
 			}
 		}

--- a/pkg/dumper/query/dumper.go
+++ b/pkg/dumper/query/dumper.go
@@ -93,7 +93,7 @@ func (d *textDumper) Dump(done chan<- struct{}, cfgTables config.Tables, concurr
 				}
 			}(tbl)
 
-			if err := d.reader.ReadTable(*tableConfig, rowChan, reader.NewReadTableOpt(tableConfig)); err != nil {
+			if err := d.reader.ReadTable(*tableConfig, rowChan); err != nil {
 				log.WithError(err).WithField("table", tbl).Error("error while reading table")
 			}
 		}

--- a/pkg/reader/engine/engine.go
+++ b/pkg/reader/engine/engine.go
@@ -80,11 +80,13 @@ func (e *Engine) GetColumns(tableName string) ([]string, error) {
 }
 
 // ReadTable returns a list of all rows in a table
-func (e *Engine) ReadTable(table config.Table, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+func (e *Engine) ReadTable(table config.Table, rowChan chan<- database.Row) error {
 	defer close(rowChan)
 
 	logger := log.WithField("table", table.Name)
 	logger.Debug("reading table data")
+
+	opts := reader.NewReadTableOpt(&table)
 
 	if len(opts.Columns) == 0 {
 		columns, err := e.GetColumns(table.Name)

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -28,7 +28,7 @@ type (
 		// FormatColumn returns a escaped table.column string
 		FormatColumn(tableName string, columnName string) string
 		// ReadTable returns a channel with all database rows
-		ReadTable(config.Table, chan<- database.Row, ReadTableOpt) error
+		ReadTable(config.Table, chan<- database.Row) error
 		// Close closes the reader resources and releases them.
 		Close() error
 	}

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -28,7 +28,7 @@ type (
 		// FormatColumn returns a escaped table.column string
 		FormatColumn(tableName string, columnName string) string
 		// ReadTable returns a channel with all database rows
-		ReadTable(string, chan<- database.Row, ReadTableOpt) error
+		ReadTable(config.Table, chan<- database.Row, ReadTableOpt) error
 		// Close closes the reader resources and releases them.
 		Close() error
 	}


### PR DESCRIPTION
Changing the Dumper engine to fetch all tables defined in the configuration instead of only the first result, allowing multiple subsets read of the same table.

This changes also removes the need for Readers to be aware of the configuration, instead a table configuration is given to it where all information needed for the ReadTable process is available.

Since the tables read/dump are concurrent, there's no guarantee of insert order with this approach.

resolves  #139
  