### PR TITLE
Add replacer pkg and functionality

### DIFF
--- a/cmd/steal.go
+++ b/cmd/steal.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hellofresh/klepto/pkg/config"
 	"github.com/hellofresh/klepto/pkg/dumper"
 	"github.com/hellofresh/klepto/pkg/reader"
+	"github.com/hellofresh/klepto/pkg/replacer"
 
 	// imports dumpers and readers
 	_ "github.com/hellofresh/klepto/pkg/dumper/mysql"
@@ -101,6 +102,7 @@ func RunSteal(opts *StealOptions) (err error) {
 	}()
 
 	source = anonymiser.NewAnonymiser(source, opts.cfgTables)
+	source = replacer.NewReplacer(source, opts.cfgTables)
 	target, err := dumper.NewDumper(dumper.ConnOpts{
 		DSN:             opts.to,
 		IsRDS:           opts.toRDS,

--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -121,3 +121,23 @@ To dump the latest 100 users with their orders:
 
 !!! info "Tip"
     You can find some [configuration examples](https://github.com/hellofresh/klepto/tree/master/examples) in Klepto's repository.
+
+### **Replacements**
+
+If you want to replace part of a value in a column you can use the `Replace` key to do so.
+
+```toml
+[[Tables]]
+  Name = "colours"
+  IgnoreData = false
+
+  [[Tables.Replace]]
+    Column = "reference"
+    Before = "print.unmade.com"
+    After = "print-dev.unmade.com"
+
+  [[Tables.Replace]]
+    Column = "reference"
+    Before = "www.cloudknit.com"
+    After = "dev.cloudknit.com"
+```

--- a/fixtures/.klepto.toml
+++ b/fixtures/.klepto.toml
@@ -32,3 +32,12 @@
   [Tables.Filter]
     Match = ""
     Limit = 0
+
+[[Tables]]
+  Name = "colours"
+  IgnoreData = false
+  
+  [[Tables.Replace]]
+    Column = "reference"
+    Before = "something.somewhere.com"
+    After = "something.somewhere.dev"

--- a/fixtures/mysql_simple.sql
+++ b/fixtures/mysql_simple.sql
@@ -23,6 +23,12 @@ CREATE TABLE order_items (
   CONSTRAINT fk_order_id FOREIGN KEY (order_id) REFERENCES orders (id)
 );
 
+CREATE TABLE colours {
+  id varchar(36) PRIMARY KEY NOT NULL,
+  name varchar(255) NOT NULL,
+  reference varchar(255) NOT NULL
+}
+
 INSERT INTO `users` VALUES ('0d60a85e-0b90-4482-a14c-108aea2557aa', 'wbo', 'wbo@hellofresh.com', true, 'm', '2017-01-01');
 INSERT INTO `users` VALUES ('39240e9f-ae09-4e95-9fd0-a712035c8ad7', 'kp', 'kp@hellofresh.com', true, NULL, '2017-01-01');
 INSERT INTO `users` VALUES ('9e4de779-d6a0-44bc-a531-20cdb97178d2', 'lp', 'lp@hellofresh.com', false, 'f', '2017-01-01');
@@ -40,3 +46,6 @@ INSERT INTO `orders` VALUES ('2b92734e-0e4c-11e8-ba89-0ed5f89f718b', '66a45c1b-1
 INSERT INTO `order_items` VALUES ('7e4e057e-1709-11e8-b642-0ed5f89f718b', 'b9bcd5e1-75e6-412d-be87-278003519717', '2018-01-01');
 INSERT INTO `order_items` VALUES ('dcad1150-1709-11e8-b642-0ed5f89f718b', '7ee31a7f-5140-483b-8ba1-fa8f116219c0', '2018-01-01');
 INSERT INTO `order_items` VALUES ('d0d80524-174a-11e8-b642-0ed5f89f718b', '453f4498-b4e0-485f-94fa-72f233bb7958', '2018-01-01');
+
+INSERT INTO `colours` VALUES ('c8868e95-9ce9-45dc-a1f0-3bed9e797677', 'red', 'https://something.somewhere.com/68923684-4028-4d7e-90f4-b67964d0b8d8');
+INSERT INTO `colours` VALUES ('1dd19834-7ff5-488c-aad8-bae3e191ac78', 'blue', 'https://something.somewhere.com/a676f8f6-b1bb-4b47-9517-f7effa9badec');

--- a/fixtures/pg_simple.sql
+++ b/fixtures/pg_simple.sql
@@ -25,6 +25,11 @@ CREATE TABLE "order_items" (
   FOREIGN KEY (order_id) REFERENCES orders(id)
 );
 
+CREATE TABLE "colours" {
+  id UUID PRIMARY KEY NOT NULL,
+  name character varying(255) NOT NULL,
+  reference character varying(255) NOT NULL
+}
 
 CREATE VIEW "users_view" AS SELECT id, username FROM "users" WHERE active=true;
 
@@ -45,6 +50,9 @@ INSERT INTO "orders" VALUES ('2b92734e-0e4c-11e8-ba89-0ed5f89f718b', '66a45c1b-1
 INSERT INTO "order_items" VALUES ('7e4e057e-1709-11e8-b642-0ed5f89f718b', 'b9bcd5e1-75e6-412d-be87-278003519717', '2018-01-01');
 INSERT INTO "order_items" VALUES ('dcad1150-1709-11e8-b642-0ed5f89f718b', '7ee31a7f-5140-483b-8ba1-fa8f116219c0', '2018-01-01');
 INSERT INTO "order_items" VALUES ('d0d80524-174a-11e8-b642-0ed5f89f718b', '453f4498-b4e0-485f-94fa-72f233bb7958', '2018-01-01');
+
+INSERT INTO `colours` VALUES ('c8868e95-9ce9-45dc-a1f0-3bed9e797677', 'red', 'https://something.somewhere.com/68923684-4028-4d7e-90f4-b67964d0b8d8');
+INSERT INTO `colours` VALUES ('1dd19834-7ff5-488c-aad8-bae3e191ac78', 'blue', 'https://something.somewhere.com/a676f8f6-b1bb-4b47-9517-f7effa9badec');
 --
 -- PostgreSQL database dump complete
 --

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,8 @@ type (
 		Anonymise map[string]string
 		// Relationship is an collection of relationship definitions.
 		Relationships []*Relationship
+		// Replace substitutes part of the column value with another.
+		Replace []*Replace
 	}
 
 	// Filter represents the way you want to filter the results.
@@ -64,6 +66,12 @@ type (
 		ReferencedTable string
 		// ReferencedKey is the referenced table primary key name.
 		ReferencedKey string
+	}
+
+	Replace struct {
+		Column string
+		Before string
+		After  string
 	}
 )
 
@@ -153,6 +161,14 @@ func WriteSample(w io.Writer) error {
 			{
 				Name:       "logs",
 				IgnoreData: true,
+			},
+			{
+				Name:       "colours",
+				IgnoreData: false,
+				Replace: []*Replace{
+					{Column: "reference", Before: "something.somewhere.com", After: "something.somewhere.dev"},
+					{Column: "reference", Before: "something.else.com", After: "something.else.dev"},
+				},
 			},
 		},
 	})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,7 @@ func TestLoadFromFile(t *testing.T) {
 
 	cfgTables, err := LoadFromFile(configPath)
 	require.NoError(t, err)
-	require.Len(t, cfgTables, 3)
+	require.Len(t, cfgTables, 4)
 
 	users := cfgTables.FindByName("users")
 	require.NotNil(t, users)
@@ -31,6 +31,9 @@ func TestLoadFromFile(t *testing.T) {
 	orders := cfgTables.FindByName("orders")
 	require.NotNil(t, orders)
 	assert.Equal(t, "users.active = TRUE", orders.Filter.Match)
+
+	colours := cfgTables.FindByName("colours")
+	require.NotNil(t, colours)
 }
 
 func TestWriteSample(t *testing.T) {
@@ -77,5 +80,22 @@ const (
   [Tables.Filter]
     Match = ""
     Limit = 0
+
+[[Tables]]
+  Name = "colours"
+  IgnoreData = false
+  [Tables.Filter]
+    Match = ""
+    Limit = 0
+
+  [[Tables.Replace]]
+    Column = "reference"
+    Before = "something.somewhere.com"
+    After = "something.somewhere.dev"
+
+  [[Tables.Replace]]
+    Column = "reference"
+    Before = "something.else.com"
+    After = "something.else.dev"
 `
 )

--- a/pkg/replacer/replacer.go
+++ b/pkg/replacer/replacer.go
@@ -1,0 +1,73 @@
+package replacer
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/hellofresh/klepto/pkg/config"
+	"github.com/hellofresh/klepto/pkg/database"
+	"github.com/hellofresh/klepto/pkg/reader"
+)
+
+type (
+	replacer struct {
+		reader.Reader
+		tables config.Tables
+	}
+)
+
+func NewReplacer(source reader.Reader, tables config.Tables) reader.Reader {
+	return &replacer{source, tables}
+}
+
+// ReadTable decorates reader.ReadTable method for modifying values published from the reader.Reader
+func (r *replacer) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+	logger := log.WithField("table", tableName)
+	logger.Debug("Loading replacer config")
+	table := r.tables.FindByName(tableName)
+
+	if table == nil {
+		logger.Debug("the table is not configured to have replacements")
+		return r.Reader.ReadTable(tableName, rowChan, opts)
+	}
+
+	// if no replacements are specified
+	if len(table.Replace) == 0 {
+		logger.Debug("Skipping replacer")
+		return r.Reader.ReadTable(tableName, rowChan, opts)
+	}
+
+	// Create read/write chanel
+	rawChan := make(chan database.Row)
+
+	go func(rowChan chan<- database.Row, rawChan chan database.Row, table *config.Table) {
+		for {
+			row, more := <-rawChan
+
+			if !more {
+				close(rowChan)
+				return
+			}
+
+			for _, replace := range table.Replace {
+				column := replace.Column
+
+				if row[column] == nil {
+					continue
+				}
+
+				row[column] = strings.Replace(fmt.Sprint(row[column]), replace.Before, replace.After, 1)
+			}
+
+			rowChan <- row
+		}
+	}(rowChan, rawChan, table)
+
+	if err := r.Reader.ReadTable(tableName, rawChan, opts); err != nil {
+		return fmt.Errorf("replacer: error while reading table: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/replacer/replacer_test.go
+++ b/pkg/replacer/replacer_test.go
@@ -1,0 +1,59 @@
+package replacer
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hellofresh/klepto/pkg/config"
+	"github.com/hellofresh/klepto/pkg/database"
+	"github.com/hellofresh/klepto/pkg/reader"
+)
+
+func TestWhenColumnIsReplaced(t *testing.T) {
+	replacer := NewReplacer(
+		&mockReader{},
+		config.Tables{
+			{
+				Name: "test",
+				Replace: []*config.Replace{
+					{Column: "column_test", Before: "something.somewhere.com", After: "something.somewhere.dev"},
+				},
+			},
+		},
+	)
+
+	rowChan := make(chan database.Row)
+	defer close(rowChan)
+
+	err := replacer.ReadTable("test", rowChan, reader.ReadTableOpt{})
+	require.NoError(t, err)
+
+	select {
+	case row := <-rowChan:
+		assert.Equal(t, "something.somewhere.dev/a676f8f6-b1bb-4b47-9517-f7effa9badec", row["column_test"])
+	case <-time.After(time.Second):
+		assert.FailNow(t, "Failing due to timeout")
+	}
+}
+
+type mockReader struct{}
+
+func (m *mockReader) GetTables() ([]string, error)        { return []string{"table_test"}, nil }
+func (m *mockReader) GetStructure() (string, error)       { return "", nil }
+func (m *mockReader) GetColumns(string) ([]string, error) { return []string{"column_test"}, nil }
+func (m *mockReader) GetPreamble() (string, error)        { return "", nil }
+func (m *mockReader) Close() error                        { return nil }
+func (m *mockReader) FormatColumn(tbl string, col string) string {
+	return fmt.Sprintf("%s.%s", strconv.Quote(tbl), strconv.Quote(col))
+}
+func (m *mockReader) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+	row := make(database.Row)
+	row["column_test"] = "something.somewhere.com/a676f8f6-b1bb-4b47-9517-f7effa9badec"
+	rowChan <- row
+	return nil
+}


### PR DESCRIPTION
Allow users to specify `[[Tables.Replace]]` when they want to substitute part of a value in a table before copying it over. 

This functionality will be especially helpful when copying over columns like the `reference` column in `palette_colour` so we can convert prod urls into dev urls. For example we'd be able to specify a configuration like this ~ 

```toml
[[Tables]]
  Name = "palette_colour"

  [[Tables.Replace]]
    Column = "reference" 
    Before = "print.unmade.com"
    After  = "print-dev.unmade.com"

  [[Tables.Replace]]
    Column = "reference"
    Before = "www.cloudknit.com"
    After = "dev.cloudknit.com"
``` 