### PR TITLE
EPS-105 - remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
 
   postgres_source:


### PR DESCRIPTION
The 'version' property in docker-compose.yml file is now officially considered obsolete.
This PR removes it.