### PR TITLE
Add config to omit columns from data transfer

### DIFF
--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -17,9 +17,10 @@ You can set a number of keys in the configuration file. Below is a list of all c
     - `Limit` - The number of results to be fetched.
     - `Sorts` - Defines how the table is sorted.
   - `Anonymise` - Indicates which columns to anonymise.
+  - `Omit` - Specifies columns to omit from the data transfer.
   - `Relationships` - Represents a relationship between the table and referenced table.
     - `Table` - The table name.
-    - `ForeignKey` - The table's foreign key. 
+    - `ForeignKey` - The table's foreign key.
     - `ReferencedTable` - The referenced table name.
     - `ReferencedKey` - The referenced table primary key.
 
@@ -90,6 +91,20 @@ Bellow are the instructions used to generate the file:
 ```sh
 go get github.com/ungerik/pkgreflect
 fake master pkgreflect -notypes -novars -norecurs vendor/github.com/icrowley/fake/
+```
+
+### **Omit**
+
+You can omit specific columns from the data transfer using the `Omit` key. Omitted columns will still exist in the target database structure, but no data will be transferred for these columns. This is useful for cases like Postgres generated columns, where the database will reject the COPY command entirely if the column is present.
+
+```toml
+[[Tables]]
+  Name = "users"
+  # Omit generated columns and sensitive data from transfer
+  Omit = ["ssn", "generated_calendar_dates"]
+  [Tables.Anonymise]
+    email = "EmailAddress"
+    first_name = "FirstName"
 ```
 
 ### **Relationships**

--- a/examples/user-orders-using-matchers.toml
+++ b/examples/user-orders-using-matchers.toml
@@ -1,5 +1,5 @@
 [[Matchers]]
-  Latest100ActiveUsers = "users.active = true ORDER BY users.created_at DESC LIMIT 100"
+Latest100ActiveUsers = "users.active = true ORDER BY users.created_at DESC LIMIT 100"
 
 [[Tables]]
   Name = "users"
@@ -11,39 +11,39 @@
     Match = "Latest100ActiveUsers"
 
 [[Tables]]
-  # Dump only orders which are related to the matching users
-  Name = "orders"
-  # Behind the scenes it will generate the following sql query:
-  # SELECT orders.* FROM orders
-  # JOIN users ON users.id = orders.user_id 
-  # WHERE users.status = 'active'
-  # ORDER BY created_at DESC
-  [[Tables.Relationships]]
-    Table = "orders"
-    ForeignKey = "user_id"
-    ReferencedTable = "users"
-    ReferencedKey = "id"
-  [Tables.Filter]
-    Match = "Latest100ActiveUsers"
+# Dump only orders which are related to the matching users
+Name = "orders"
+# Behind the scenes it will generate the following sql query:
+# SELECT orders.* FROM orders
+# JOIN users ON users.id = orders.user_id
+# WHERE users.status = 'active'
+# ORDER BY created_at DESC
+[[Tables.Relationships]]
+Table = "orders"
+ForeignKey = "user_id"
+ReferencedTable = "users"
+ReferencedKey = "id"
+[Tables.Filter]
+Match = "Latest100ActiveUsers"
 
 [[Tables]]
-  # Dump only order items which are related to the matching users orders
-  Name = "order_items"
-  # Behind the scenes it will generate the following sql query:
-  # SELECT order_items.* FROM order_items
-  # JOIN orders ON orders.id = order_items.order_id
-  # JOIN users ON users.id = orders.user_id 
-  # WHERE users.status = 'active'
-  # ORDER BY created_at DESC
-  [[Tables.Relationships]]
-    Table = "order_items"
-    ForeignKey = "order_id"
-    ReferencedTable = "orders"
-    ReferencedKey = "id"
-  [[Tables.Relationships]]
-    Table = "orders"
-    ForeignKey = "user_id"
-    ReferencedTable = "users"
-    ReferencedKey = "id"
-  [Tables.Filter]
-    Match = "Latest100ActiveUsers"
+# Dump only order items which are related to the matching users orders
+Name = "order_items"
+# Behind the scenes it will generate the following sql query:
+# SELECT order_items.* FROM order_items
+# JOIN orders ON orders.id = order_items.order_id
+# JOIN users ON users.id = orders.user_id
+# WHERE users.status = 'active'
+# ORDER BY created_at DESC
+[[Tables.Relationships]]
+Table = "order_items"
+ForeignKey = "order_id"
+ReferencedTable = "orders"
+ReferencedKey = "id"
+[[Tables.Relationships]]
+Table = "orders"
+ForeignKey = "user_id"
+ReferencedTable = "users"
+ReferencedKey = "id"
+[Tables.Filter]
+Match = "Latest100ActiveUsers"

--- a/examples/user-orders.toml
+++ b/examples/user-orders.toml
@@ -12,45 +12,45 @@
       created_at = "desc"
 
 [[Tables]]
-  # Dump only orders which are related to the matching users
-  Name = "orders"
-  # Behind the scenes it will generate the following sql query:
-  # SELECT orders.* FROM orders
-  # JOIN users ON users.id = orders.user_id 
-  # WHERE users.status = 'active'
-  # ORDER BY created_at DESC
-  [[Tables.Relationships]]
-    Table = "orders"
-    ForeignKey = "user_id"
-    ReferencedTable = "users"
-    ReferencedKey = "id"
-  [Tables.Filter]
-    Match = "users.active = true"
-    Limit = 100
-    [Tables.Filter.Sorts]
-      created_at = "desc"
+# Dump only orders which are related to the matching users
+Name = "orders"
+# Behind the scenes it will generate the following sql query:
+# SELECT orders.* FROM orders
+# JOIN users ON users.id = orders.user_id
+# WHERE users.status = 'active'
+# ORDER BY created_at DESC
+[[Tables.Relationships]]
+Table = "orders"
+ForeignKey = "user_id"
+ReferencedTable = "users"
+ReferencedKey = "id"
+[Tables.Filter]
+Match = "users.active = true"
+Limit = 100
+[Tables.Filter.Sorts]
+created_at = "desc"
 
 [[Tables]]
-  # Dump only order items which are related to the matching users orders
-  Name = "order_items"
-  # Behind the scenes it will generate the following sql query:
-  # SELECT order_items.* FROM order_items
-  # JOIN orders ON orders.id = order_items.order_id
-  # JOIN users ON users.id = orders.user_id 
-  # WHERE users.status = 'active'
-  # ORDER BY created_at DESC
-  [[Tables.Relationships]]
-    Table = "order_items"
-    ForeignKey = "order_id"
-    ReferencedTable = "orders"
-    ReferencedKey = "id"
-  [[Tables.Relationships]]
-    Table = "orders"
-    ForeignKey = "user_id"
-    ReferencedTable = "users"
-    ReferencedKey = "id"
-  [Tables.Filter]
-    Match = "users.active = true"
-    Limit = 100
-    [Tables.Filter.Sorts]
-      created_at = "desc"
+# Dump only order items which are related to the matching users orders
+Name = "order_items"
+# Behind the scenes it will generate the following sql query:
+# SELECT order_items.* FROM order_items
+# JOIN orders ON orders.id = order_items.order_id
+# JOIN users ON users.id = orders.user_id
+# WHERE users.status = 'active'
+# ORDER BY created_at DESC
+[[Tables.Relationships]]
+Table = "order_items"
+ForeignKey = "order_id"
+ReferencedTable = "orders"
+ReferencedKey = "id"
+[[Tables.Relationships]]
+Table = "orders"
+ForeignKey = "user_id"
+ReferencedTable = "users"
+ReferencedKey = "id"
+[Tables.Filter]
+Match = "users.active = true"
+Limit = 100
+[Tables.Filter.Sorts]
+created_at = "desc"

--- a/examples/user.toml
+++ b/examples/user.toml
@@ -1,7 +1,7 @@
 [[Tables]]
-  # Dump the database structure without importing data
-  Name = "user_history"
-  IgnoreData = true
+# Dump the database structure without importing data
+Name = "user_history"
+IgnoreData = true
 
 [[Tables]]
   Name = "users"

--- a/fixtures/.klepto.toml
+++ b/fixtures/.klepto.toml
@@ -1,34 +1,36 @@
 [Matchers]
-  ActiveUsers = "users.active = TRUE"
+ActiveUsers = "users.active = TRUE"
 
 [[Tables]]
-  Name = "users"
-  IgnoreData = false
-  [Tables.Filter]
-    Match = "users.active = TRUE"
-    Limit = 100
-    [Tables.Filter.Sorts]
-      "users.id" = "asc"
-  [Tables.Anonymise]
-    email = "EmailAddress"
-    firstName = "FirstName"
+Name = "users"
+IgnoreData = false
+Omit = ["password", "ssn", "api_key"]
+[Tables.Filter]
+Match = "users.active = TRUE"
+Limit = 100
+[Tables.Filter.Sorts]
+"users.id" = "asc"
+[Tables.Anonymise]
+email = "EmailAddress"
+firstName = "FirstName"
 
 [[Tables]]
-  Name = "orders"
-  IgnoreData = false
-  [Tables.Filter]
-    Match = "ActiveUsers"
-    Limit = 10
+Name = "orders"
+IgnoreData = false
+Omit = ["internal_notes", "cost_basis"]
+[Tables.Filter]
+Match = "ActiveUsers"
+Limit = 10
 
-  [[Tables.Relationships]]
-    Table = ""
-    ForeignKey = "user_id"
-    ReferencedTable = "users"
-    ReferencedKey = "id"
+[[Tables.Relationships]]
+Table = ""
+ForeignKey = "user_id"
+ReferencedTable = "users"
+ReferencedKey = "id"
 
 [[Tables]]
-  Name = "logs"
-  IgnoreData = true
-  [Tables.Filter]
-    Match = ""
-    Limit = 0
+Name = "logs"
+IgnoreData = true
+[Tables.Filter]
+Match = ""
+Limit = 0

--- a/pkg/anonymiser/anonymiser_test.go
+++ b/pkg/anonymiser/anonymiser_test.go
@@ -85,6 +85,18 @@ func TestReadTable(t *testing.T) {
 			opts:     reader.ReadTableOpt{},
 			config:   config.Tables{{Name: "test", Anonymise: map[string]string{"column_test1": "CharactersN:invalid", "column_test2": "Password:1:2:yes"}}},
 		},
+		{
+			scenario: "when column is omitted from data",
+			function: testWhenColumnIsOmittedFromData,
+			opts:     reader.ReadTableOpt{},
+			config:   config.Tables{{Name: "test", Omit: []string{"column_to_omit"}}},
+		},
+		{
+			scenario: "when column is both omitted from data and anonymised",
+			function: testWhenColumnIsBothOmittedFromDataAndAnonymised,
+			opts:     reader.ReadTableOpt{},
+			config:   config.Tables{{Name: "test", Omit: []string{"column_to_omit"}, Anonymise: map[string]string{"column_test": "FirstName"}}},
+		},
 	}
 
 	for _, test := range tests {
@@ -260,19 +272,179 @@ func testWhenColumnAnonymiserRequireArgsInvalidValues(t *testing.T, opts reader.
 	}
 }
 
+func testWhenColumnIsOmittedFromData(t *testing.T, opts reader.ReadTableOpt, tables config.Tables) {
+	anonymiser := NewAnonymiser(&mockReader{}, tables)
+
+	// Test GetColumns filters out omitted columns
+	columns, err := anonymiser.GetColumns("test")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"column_test"}, columns)
+	assert.NotContains(t, columns, "column_to_omit")
+
+	// Test ReadTable removes omitted columns from row data
+	rowChan := make(chan database.Row)
+	defer close(rowChan)
+
+	err = anonymiser.ReadTable("test", rowChan, opts)
+	require.NoError(t, err)
+
+	timeoutChan := time.After(waitTimeout)
+	select {
+	case row := <-rowChan:
+		assert.Contains(t, row, "column_test")
+		assert.NotContains(t, row, "column_to_omit")
+	case <-timeoutChan:
+		assert.FailNow(t, "Failing due to timeout")
+	}
+}
+
+func testWhenColumnIsBothOmittedFromDataAndAnonymised(t *testing.T, opts reader.ReadTableOpt, tables config.Tables) {
+	anonymiser := NewAnonymiser(&mockReader{}, tables)
+
+	// Test GetColumns filters out omitted columns (for data transfer)
+	columns, err := anonymiser.GetColumns("test")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"column_test"}, columns)
+	assert.NotContains(t, columns, "column_to_omit")
+
+	// Test ReadTable removes omitted columns and anonymises remaining columns
+	rowChan := make(chan database.Row)
+	defer close(rowChan)
+
+	err = anonymiser.ReadTable("test", rowChan, opts)
+	require.NoError(t, err)
+
+	timeoutChan := time.After(waitTimeout)
+	select {
+	case row := <-rowChan:
+		assert.Contains(t, row, "column_test")
+		assert.NotContains(t, row, "column_to_omit")
+		assert.NotEqual(t, "to_be_anonimised", row["column_test"])
+	case <-timeoutChan:
+		assert.FailNow(t, "Failing due to timeout")
+	}
+}
+
+func TestGetColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tables   config.Tables
+		expected []string
+	}{
+		{
+			name:     "when no omit config",
+			tables:   config.Tables{{Name: "test"}},
+			expected: []string{"column_test", "column_to_omit"},
+		},
+		{
+			name:     "when table not found",
+			tables:   config.Tables{{Name: "other"}},
+			expected: []string{"column_test", "column_to_omit"},
+		},
+		{
+			name:     "when one column is omitted",
+			tables:   config.Tables{{Name: "test", Omit: []string{"column_to_omit"}}},
+			expected: []string{"column_test"},
+		},
+		{
+			name:     "when multiple columns are omitted",
+			tables:   config.Tables{{Name: "test", Omit: []string{"column_to_omit", "column_test"}}},
+			expected: []string{},
+		},
+		{
+			name:     "when non-existent column is omitted",
+			tables:   config.Tables{{Name: "test", Omit: []string{"non_existent"}}},
+			expected: []string{"column_test", "column_to_omit"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			anonymiser := NewAnonymiser(&mockReader{}, test.tables)
+			columns, err := anonymiser.GetColumns("test")
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, columns)
+		})
+	}
+}
+
+func TestStructureVsDataBehavior(t *testing.T) {
+	// This test verifies that the Omit configuration only affects data transfer and not
+	// the database structure.
+	//
+	// Structure should include all columns, data transfer should omit the specified columns
+
+	tables := config.Tables{{Name: "test", Omit: []string{"column_to_omit"}}}
+	anonymiser := NewAnonymiser(&mockReaderWithStructure{}, tables)
+
+	// GetStructure returns all columns
+	structure, err := anonymiser.GetStructure()
+	require.NoError(t, err)
+	assert.Contains(t, structure, "column_test")
+	assert.Contains(t, structure, "column_to_omit")
+
+	// GetColumns filters out omitted columns
+	columns, err := anonymiser.GetColumns("test")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"column_test"}, columns)
+	assert.NotContains(t, columns, "column_to_omit")
+
+	// ReadTable removes omitted columns from row data
+	rowChan := make(chan database.Row)
+	defer close(rowChan)
+
+	err = anonymiser.ReadTable("test", rowChan, reader.ReadTableOpt{})
+	require.NoError(t, err)
+
+	timeoutChan := time.After(waitTimeout)
+	select {
+	case row := <-rowChan:
+		assert.Contains(t, row, "column_test")
+		assert.NotContains(t, row, "column_to_omit")
+	case <-timeoutChan:
+		assert.FailNow(t, "Failing due to timeout")
+	}
+}
+
 type mockReader struct{}
 
-func (m *mockReader) GetTables() ([]string, error)        { return []string{"table_test"}, nil }
-func (m *mockReader) GetStructure() (string, error)       { return "", nil }
-func (m *mockReader) GetColumns(string) ([]string, error) { return []string{"column_test"}, nil }
-func (m *mockReader) GetPreamble() (string, error)        { return "", nil }
-func (m *mockReader) Close() error                        { return nil }
+func (m *mockReader) GetTables() ([]string, error)  { return []string{"table_test"}, nil }
+func (m *mockReader) GetStructure() (string, error) { return "", nil }
+func (m *mockReader) GetColumns(string) ([]string, error) {
+	return []string{"column_test", "column_to_omit"}, nil
+}
+func (m *mockReader) GetPreamble() (string, error) { return "", nil }
+func (m *mockReader) Close() error                 { return nil }
 func (m *mockReader) FormatColumn(tbl string, col string) string {
 	return fmt.Sprintf("%s.%s", strconv.Quote(tbl), strconv.Quote(col))
 }
 func (m *mockReader) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
 	row := make(database.Row)
 	row["column_test"] = "to_be_anonimised"
+	row["column_to_omit"] = "sensitive_data"
+	rowChan <- row
+	return nil
+}
+
+type mockReaderWithStructure struct{}
+
+func (m *mockReaderWithStructure) GetTables() ([]string, error) { return []string{"test"}, nil }
+func (m *mockReaderWithStructure) GetStructure() (string, error) {
+	return "CREATE TABLE test (column_test VARCHAR(255), column_to_omit VARCHAR(255));", nil
+}
+func (m *mockReaderWithStructure) GetColumns(string) ([]string, error) {
+	return []string{"column_test", "column_to_omit"}, nil
+}
+func (m *mockReaderWithStructure) Close() error { return nil }
+func (m *mockReaderWithStructure) FormatColumn(tbl string, col string) string {
+	return fmt.Sprintf("%s.%s", strconv.Quote(tbl), strconv.Quote(col))
+}
+func (m *mockReaderWithStructure) ReadTable(tableName string, rowChan chan<- database.Row, opts reader.ReadTableOpt) error {
+	row := make(database.Row)
+	row["column_test"] = "to_be_anonimised"
+	row["column_to_omit"] = "sensitive_data"
 	rowChan <- row
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,8 @@ type (
 		Filter Filter
 		// Anonymise anonymises columns.
 		Anonymise map[string]string
+		// Omit specifies columns to omit from the data transfer.
+		Omit []string
 		// Relationship is an collection of relationship definitions.
 		Relationships []*Relationship
 	}
@@ -135,6 +137,7 @@ func WriteSample(w io.Writer) error {
 					Limit: 100,
 				},
 				Anonymise: map[string]string{"firstName": "FirstName", "email": "EmailAddress"},
+				Omit:      []string{"generatedKey"},
 			},
 			{
 				Name: "orders",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -49,6 +49,7 @@ const (
 [[Tables]]
   Name = "users"
   IgnoreData = false
+  Omit = ["generatedKey"]
   [Tables.Filter]
     Match = "users.active = TRUE"
     Limit = 100


### PR DESCRIPTION
We ran into an issue when using Postgres generated columns, where Postgres will reject the COPY operation outright if they are included in the input. In order to copy tables that include generated columns, we needed to prevent those columns from being included in the kelpto transfer.

This PR extends the anonymizer to support an `Omit` config option. Columns listed under `Omit` will still be included in the structural transfer, but will be removed in the data transfer phase.
