### PR TITLE
Strip \restrict,\unrestrict psql meta commands from pg_dump output

### DIFF
--- a/pkg/reader/postgres/pg_dump.go
+++ b/pkg/reader/postgres/pg_dump.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"bytes"
 	"os/exec"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -55,5 +56,16 @@ func (p *PgDump) GetStructure() (string, error) {
 		logger.Error("failed to load schema for table")
 	}
 
-	return buf.String(), nil
+	// Process the output to drop lines starting with /restrict or /unrestrict
+	output := buf.String()
+	lines := strings.Split(output, "\n")
+	filteredLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, `\restrict`) && !strings.HasPrefix(trimmed, `\unrestrict`) {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+
+	return strings.Join(filteredLines, "\n"), nil
 }


### PR DESCRIPTION
Since this [August release](https://www.postgresql.org/about/news/postgresql-176-1610-1514-1419-1322-and-18-beta-3-released-3118/), `pg_dump` has started including `\restrict` and `\unrestrict` lines in its output. These are `psql` meta commands meant to guard against dumps from untrusted systems triggering command execution on the local machine.

Klepto (via lib/pq) expects `pg_dump` output to be valid SQL and fails when run with newer versions.

This PR strips the restrict/unrestrict lines from `pg_dump` output prior to passing it along to the rest of the stack.